### PR TITLE
Fix enqueue_active_tasklet task lock guard not work

### DIFF
--- a/kernel/src/asynk/mod.rs
+++ b/kernel/src/asynk/mod.rs
@@ -120,7 +120,7 @@ pub fn enqueue_active_tasklet(t: Arc<Tasklet>) {
         scheduler::current_thread_id()
     );
     let mut q = ASYNC_WORK_QUEUE.get_active_queue();
-    let _ = t.lock();
+    let _guard = t.lock();
     q.push_back(t.clone());
     #[cfg(debugging_scheduler)]
     crate::trace!(


### PR DESCRIPTION
https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=99a4fabd5706646c34a3c933eb48a27e

The behavior of `let _` is different from `let _guard`, which releases the variable immediately. This causes the lock to fail to protect against any operation.

I'm not really sure what this lock does, since the queue appears to be thread-safe. maybe this lock access can be remove.