### PR TITLE
fix: Distinguish EOF from blocking mode in tcp socket

### DIFF
--- a/kernel/src/net/connection.rs
+++ b/kernel/src/net/connection.rs
@@ -495,15 +495,14 @@ impl Connection {
 
                             let result = posix_socket.send(f, 0, is_nonblocking, ipc_reply.clone());
 
-                            match result.as_ref() {
-                                Ok(0) => {
-                                    log::debug!(
-                                        "[Connection] handle Send socket_fd={} , recv 0 data , wait for socket",
-                                        socket_fd
-                                    );
-                                    None
-                                }
-                                _ => Some(result),
+                            if let Err(SocketError::WouldBlock) = result.as_ref() {
+                                log::debug!(
+                                    "[Connection] handle Send socket_fd={} , recv 0 data , wait for socket",
+                                    socket_fd,
+                                );
+                                None
+                            } else {
+                                Some(result)
                             }
                         },
                     );
@@ -534,15 +533,14 @@ impl Connection {
                                 ipc_reply.clone(),
                             );
 
-                            match result.as_ref() {
-                                Ok(0) => {
-                                    log::debug!(
-                                        "[Connection] handle SendTo socket_fd={} , blocking wait for socket",
-                                        socket_fd
-                                    );
-                                    None
-                                }
-                                _ => Some(result),
+                            if let Err(SocketError::WouldBlock) = result.as_ref() {
+                                log::debug!(
+                                    "[Connection] handle SendTo socket_fd={} , blocking wait for socket",
+                                    socket_fd,
+                                );
+                                None
+                            } else {
+                                Some(result)
                             }
                         },
                     );
@@ -578,15 +576,14 @@ impl Connection {
                                 ipc_reply.clone(),
                             );
 
-                            match result.as_ref() {
-                                Ok(0) => {
-                                    log::debug!(
-                                        "[Connection] handle SendMsg socket_fd={} , blocking wait for socket",
-                                        socket_fd
-                                    );
-                                    None
-                                }
-                                _ => Some(result),
+                            if let Err(SocketError::WouldBlock) = result.as_ref() {
+                                log::debug!(
+                                    "[Connection] handle SendMsg socket_fd={} , blocking wait for socket",
+                                    socket_fd,
+                                );
+                                None
+                            } else {
+                                Some(result)
                             }
                         },
                     );
@@ -607,15 +604,14 @@ impl Connection {
                             let mut posix_socket = posix_socket.borrow_mut();
                             let result = posix_socket.recv(f, is_nonblocking, ipc_reply.clone());
 
-                            match result.as_ref() {
-                                Ok(0) => {
-                                    log::debug!(
-                                        "[Connection] handle Recv socket_fd={} , blocking wait for socket",
-                                        socket_fd
-                                    );
-                                    None
-                                }
-                                _ => Some(result),
+                            if let Err(SocketError::WouldBlock) = result.as_ref() {
+                                log::debug!(
+                                    "[Connection] handle Recv socket_fd={} , blocking wait for socket",
+                                    socket_fd,
+                                );
+                                None
+                            } else {
+                                Some(result)
                             }
                         },
                     );
@@ -637,15 +633,14 @@ impl Connection {
                             let result =
                                 posix_socket.recvfrom(f, is_nonblocking, ipc_reply.clone());
 
-                            match result.as_ref() {
-                                Ok(0) => {
-                                    log::debug!(
+                            if let Err(SocketError::WouldBlock) = result.as_ref() {
+                                log::debug!(
                                         "[Connection] handle RecvFrom socket_fd={} , blocking wait for socket",
-                                        socket_fd
+                                        socket_fd,
                                     );
-                                    None
-                                }
-                                _ => Some(result),
+                                None
+                            } else {
+                                Some(result)
                             }
                         },
                     );
@@ -666,15 +661,14 @@ impl Connection {
                             let mut posix_socket = posix_socket.borrow_mut();
                             let result = posix_socket.recvmsg(f, is_nonblocking, ipc_reply.clone());
 
-                            match result.as_ref() {
-                                Ok(0) => {
-                                    log::debug!(
+                            if let Err(SocketError::WouldBlock) = result.as_ref() {
+                                log::debug!(
                                         "[Connection] handle RecvMsg socket_fd={} , blocking wait for socket",
-                                        socket_fd
+                                        socket_fd,
                                     );
-                                    None
-                                }
-                                _ => Some(result),
+                                None
+                            } else {
+                                Some(result)
                             }
                         },
                     );

--- a/kernel/src/net/socket/icmp.rs
+++ b/kernel/src/net/socket/icmp.rs
@@ -248,7 +248,7 @@ impl PosixSocket for IcmpSocket<'static> {
                             "icmp socket not ready for send_queue={:?}",
                             socket.send_queue()
                         );
-                        Ok(0)
+                        Err(SocketError::WouldBlock)
                     } else {
                         // O_NONBLOCK is set for return immediately,
                         // ICMP is state-less socket , always return EAGAIN
@@ -308,7 +308,7 @@ impl PosixSocket for IcmpSocket<'static> {
                             "no data for icmp recvmsg recv_queue={:?}",
                             socket.recv_queue()
                         );
-                        Ok(0)
+                        Err(SocketError::WouldBlock)
                     } else {
                         // O_NONBLOCK is set for return immediately,
                         // ICMP is state-less socket , always return EAGAIN

--- a/kernel/src/net/socket/socket_err.rs
+++ b/kernel/src/net/socket/socket_err.rs
@@ -22,6 +22,9 @@ pub enum SocketError {
     #[error("Try again")]
     TryAgain,
 
+    #[error("Operation needs to block to complete")]
+    WouldBlock,
+
     #[error("Posix err {0} , {1}")]
     PosixError(i32, String),
 

--- a/kernel/src/net/socket/udp.rs
+++ b/kernel/src/net/socket/udp.rs
@@ -230,7 +230,7 @@ impl PosixSocket for UdpSocket<'static> {
                             "blocking : udp socket not ready for send_queue={:?}",
                             socket.send_queue()
                         );
-                        Ok(0)
+                        Err(SocketError::WouldBlock)
                     } else {
                         // O_NONBLOCK is set for return immediately,
                         // UDP is state-less socket , always return EAGAIN
@@ -319,7 +319,7 @@ impl PosixSocket for UdpSocket<'static> {
                             "blocking : no data for udp recvfrom recv_queue={:?}",
                             socket.recv_queue()
                         );
-                        Ok(0)
+                        Err(SocketError::WouldBlock)
                     } else {
                         // O_NONBLOCK is set for return immediately,
                         // UDP is state-less socket , always return EAGAIN

--- a/kernel/tests/net/net_utils.rs
+++ b/kernel/tests/net/net_utils.rs
@@ -34,7 +34,8 @@ use libc::{sockaddr_in, sockaddr_in6, AF_INET, AF_INET6, IN6ADDR_LOOPBACK_INIT};
 use semihosting::println;
 use smoltcp::wire::{IpAddress, IpEndpoint};
 
-const TEST_BLOCK_MODE: usize = 1;
+// Block mode test iterations: 1st for data message, 2nd for EOF
+const TEST_BLOCK_MODE: usize = 2;
 const TEST_NONBLOCK_MODE: usize = 20;
 const TEST_IO_MODE: usize = TEST_BLOCK_MODE;
 


### PR DESCRIPTION
Introduce SocketError::WouldBlock for blocking state, keeping 0 exclusively for EOF to avoid ambiguity.