### PR TITLE
fix: InterruptGuard lives not long enough to protect concurrent access

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -233,7 +233,7 @@ mod tests {
 
     #[panic_handler]
     fn oops(info: &PanicInfo) -> ! {
-        let _ = DisableInterruptGuard::new();
+        let _dig = DisableInterruptGuard::new();
         semihosting::println!("{}", info);
         semihosting::println!("Oops: {}", info.message());
         loop {}

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -233,7 +233,7 @@ mod tests {
 
     #[panic_handler]
     fn oops(info: &PanicInfo) -> ! {
-        let _dig = DisableInterruptGuard::new();
+        let _guard = DisableInterruptGuard::new();
         semihosting::println!("{}", info);
         semihosting::println!("Oops: {}", info.message());
         loop {}

--- a/kernel/src/scheduler/mod.rs
+++ b/kernel/src/scheduler/mod.rs
@@ -421,7 +421,7 @@ pub(crate) extern "C" fn schedule() -> ! {
 
 #[inline]
 pub fn current_thread() -> ThreadNode {
-    let _ = DisableInterruptGuard::new();
+    let _dig = DisableInterruptGuard::new();
     let my_id = arch::current_cpu_id();
     let t = unsafe { RUNNING_THREADS[my_id].assume_init_ref().clone() };
     t
@@ -429,7 +429,7 @@ pub fn current_thread() -> ThreadNode {
 
 #[inline]
 pub fn current_thread_id() -> usize {
-    let _ = DisableInterruptGuard::new();
+    let _dig = DisableInterruptGuard::new();
     let my_id = arch::current_cpu_id();
     let t = unsafe { RUNNING_THREADS[my_id].assume_init_ref() };
     Thread::id(t)

--- a/kernel/src/scheduler/mod.rs
+++ b/kernel/src/scheduler/mod.rs
@@ -421,7 +421,7 @@ pub(crate) extern "C" fn schedule() -> ! {
 
 #[inline]
 pub fn current_thread() -> ThreadNode {
-    let _dig = DisableInterruptGuard::new();
+    let _guard = DisableInterruptGuard::new();
     let my_id = arch::current_cpu_id();
     let t = unsafe { RUNNING_THREADS[my_id].assume_init_ref().clone() };
     t
@@ -429,7 +429,7 @@ pub fn current_thread() -> ThreadNode {
 
 #[inline]
 pub fn current_thread_id() -> usize {
-    let _dig = DisableInterruptGuard::new();
+    let _guard = DisableInterruptGuard::new();
     let my_id = arch::current_cpu_id();
     let t = unsafe { RUNNING_THREADS[my_id].assume_init_ref() };
     Thread::id(t)

--- a/kernel/src/time/mod.rs
+++ b/kernel/src/time/mod.rs
@@ -46,7 +46,7 @@ pub fn reset_systick() {
 }
 
 pub extern "C" fn handle_tick_increment() {
-    let _ = DisableInterruptGuard::new();
+    let _dig = DisableInterruptGuard::new();
     let mut need_schedule = false;
     // FIXME: aarch64 and riscv64 need to be supported
     if arch::current_cpu_id() == 0 {

--- a/kernel/src/time/mod.rs
+++ b/kernel/src/time/mod.rs
@@ -46,7 +46,7 @@ pub fn reset_systick() {
 }
 
 pub extern "C" fn handle_tick_increment() {
-    let _dig = DisableInterruptGuard::new();
+    let _guard = DisableInterruptGuard::new();
     let mut need_schedule = false;
     // FIXME: aarch64 and riscv64 need to be supported
     if arch::current_cpu_id() == 0 {


### PR DESCRIPTION
Description: InterruptGuard lives not long enough to protect concurrent access

Reason: use _ the guard returned by lock() is dropped right away on that first line and the lock isn't locked when resource is accessed.

fixes #11 