### PR TITLE
Add warning and return None when double free

### DIFF
--- a/kernel/src/allocator/llff/hole.rs
+++ b/kernel/src/allocator/llff/hole.rs
@@ -417,7 +417,10 @@ impl HoleList {
     pub unsafe fn deallocate(&mut self, ptr: NonNull<u8>, layout: &Layout) -> usize {
         // Safety: `ptr` is a previously allocated memory block with the same
         //         alignment as `align`. This is upheld by the caller.
-        let old_block = used_block_hdr_for_allocation(ptr, layout.align()).cast::<UsedBlockHdr>();
+        let Some(old_block) = used_block_hdr_for_allocation(ptr, layout.align()) else {
+            return 0;
+        };
+        let old_block = old_block.cast::<UsedBlockHdr>();
         let hole_addr_u8 = old_block.as_ptr() as *mut u8;
         let hole_size = old_block.as_ref().common.size - SIZE_USED;
 
@@ -428,7 +431,10 @@ impl HoleList {
     pub unsafe fn deallocate_unknown_align(&mut self, ptr: NonNull<u8>) -> usize {
         // Safety: `ptr` is a previously allocated memory block with the same
         //         alignment as `align`. This is upheld by the caller.
-        let old_block = used_block_hdr_for_allocation_unknown_align(ptr).cast::<UsedBlockHdr>();
+        let Some(old_block) = used_block_hdr_for_allocation_unknown_align(ptr) else {
+            return 0;
+        };
+        let old_block = old_block.cast::<UsedBlockHdr>();
         let hole_addr_u8 = old_block.as_ptr() as *mut u8;
         let hole_size = old_block.as_ref().common.size - SIZE_USED;
 

--- a/kernel/src/allocator/llff/mod.rs
+++ b/kernel/src/allocator/llff/mod.rs
@@ -215,7 +215,7 @@ impl Heap {
     ) -> Option<NonNull<u8>> {
         // Safety: `ptr` is a previously allocated memory block with the same
         //         alignment as `align`. This is upheld by the caller.
-        let old_size = size_of_allocation(ptr, layout.align());
+        let old_size = size_of_allocation(ptr, layout.align())?;
 
         if new_size <= old_size {
             return Some(ptr);
@@ -240,7 +240,7 @@ impl Heap {
     ) -> Option<NonNull<u8>> {
         // Safety: `ptr` is a previously allocated memory block with the same
         //         alignment as `align`. This is upheld by the caller.
-        let old_size = size_of_allocation_unknown_align(ptr);
+        let old_size = size_of_allocation_unknown_align(ptr)?;
         if new_size <= old_size {
             return Some(ptr);
         }

--- a/kernel/src/allocator/tlsf/mod.rs
+++ b/kernel/src/allocator/tlsf/mod.rs
@@ -849,7 +849,10 @@ impl<'pool, FLBitmap: BinInteger, SLBitmap: BinInteger, const FLLEN: usize, cons
     pub unsafe fn deallocate(&mut self, ptr: NonNull<u8>, align: usize) -> usize {
         // Safety: `ptr` is a previously allocated memory block with the same
         //         alignment as `align`. This is upheld by the caller.
-        let block = used_block_hdr_for_allocation(ptr, align).cast::<BlockHdr>();
+        let Some(block) = used_block_hdr_for_allocation(ptr, align) else {
+            return 0;
+        };
+        let block = block.cast::<BlockHdr>();
         self.deallocate_block(block)
     }
 
@@ -869,7 +872,10 @@ impl<'pool, FLBitmap: BinInteger, SLBitmap: BinInteger, const FLLEN: usize, cons
     pub(crate) unsafe fn deallocate_unknown_align(&mut self, ptr: NonNull<u8>) -> usize {
         // Safety: `ptr` is a previously allocated memory block. This is upheld
         //         by the caller.
-        let block = used_block_hdr_for_allocation_unknown_align(ptr).cast::<BlockHdr>();
+        let Some(block) = used_block_hdr_for_allocation_unknown_align(ptr) else {
+            return 0;
+        };
+        let block = block.cast::<BlockHdr>();
         self.deallocate_block(block)
     }
 
@@ -975,7 +981,7 @@ impl<'pool, FLBitmap: BinInteger, SLBitmap: BinInteger, const FLLEN: usize, cons
     ) -> Option<NonNull<u8>> {
         // Safety: `ptr` is a previously allocated memory block with the same
         //         alignment as `align`. This is upheld by the caller.
-        let block = used_block_hdr_for_allocation(ptr, new_layout.align());
+        let block = used_block_hdr_for_allocation(ptr, new_layout.align())?;
 
         // Do this early so that the compiler can de-duplicate common
         // subexpressions such as `block.as_ref().common.size - SIZE_USED`
@@ -1007,7 +1013,7 @@ impl<'pool, FLBitmap: BinInteger, SLBitmap: BinInteger, const FLLEN: usize, cons
     ) -> Option<NonNull<u8>> {
         // Safety: `ptr` is a previously allocated memory block with the same
         //         alignment as `align`. This is upheld by the caller.
-        let block = used_block_hdr_for_allocation_unknown_align(ptr);
+        let block = used_block_hdr_for_allocation_unknown_align(ptr)?;
 
         // Do this early so that the compiler can de-duplicate common
         // subexpressions such as `block.as_ref().common.size - SIZE_USED`


### PR DESCRIPTION
Add a "magic number" field or bitflag to allocated memory headers. Set this value uniquely when allocating memory and invalidate it explicitly upon freeing.

fixes https://github.com/vivoblueos/kernel/issues/12