### PR TITLE
feat: Add IsNotNull trait

### DIFF
--- a/infra/src/lib.rs
+++ b/infra/src/lib.rs
@@ -37,3 +37,19 @@ pub mod spinarc;
 pub mod string;
 pub mod tinyarc;
 pub mod tinyrwlock;
+
+pub trait IsNotNull {
+    fn is_not_null(&self) -> bool;
+}
+
+impl<T> IsNotNull for *const T {
+    fn is_not_null(&self) -> bool {
+        !self.is_null()
+    }
+}
+
+impl<T> IsNotNull for *mut T {
+    fn is_not_null(&self) -> bool {
+        !self.is_null()
+    }
+}

--- a/kernel/src/arch/aarch64/exception.rs
+++ b/kernel/src/arch/aarch64/exception.rs
@@ -123,7 +123,7 @@ extern "C" fn might_switch(to: &Context, from: &Context) -> usize {
         return from_ptr as usize;
     }
     let saved_sp_ptr: *mut usize = unsafe { from.x0 as *mut usize };
-    if !saved_sp_ptr.is_null() {
+    if saved_sp_ptr.is_not_null() {
         unsafe {
             sideeffect();
             saved_sp_ptr.write_volatile(from_ptr as usize)
@@ -131,7 +131,7 @@ extern "C" fn might_switch(to: &Context, from: &Context) -> usize {
     }
     let hook: *mut ContextSwitchHookHolder =
         unsafe { from.x2 as *mut scheduler::ContextSwitchHookHolder<'_> };
-    if !hook.is_null() {
+    if hook.is_not_null() {
         sideeffect();
         unsafe {
             scheduler::save_context_finish_hook(Some(&mut *hook));

--- a/kernel/src/arch/arm/mod.rs
+++ b/kernel/src/arch/arm/mod.rs
@@ -22,6 +22,7 @@ use crate::{
     scheduler,
     support::{sideeffect, Region, RegionalObjectBuilder},
     syscalls::{dispatch_syscall, Context as ScContext},
+    types::IsNotNull,
 };
 use core::{
     fmt,
@@ -254,7 +255,7 @@ fn handle_svc_switch(ctx: &Context) -> usize {
     assert_eq!(ctx.r7, NR_SWITCH);
     let sp = ctx as *const _ as usize;
     let saved_sp_ptr: *mut usize = unsafe { ctx.r0 as *mut usize };
-    if !saved_sp_ptr.is_null() {
+    if saved_sp_ptr.is_not_null() {
         // FIXME: rustc opt the write out if not setting it volatile.
         unsafe {
             sideeffect();
@@ -262,7 +263,7 @@ fn handle_svc_switch(ctx: &Context) -> usize {
         };
     }
     let hook: *mut ContextSwitchHookHolder = unsafe { ctx.r2 as *mut ContextSwitchHookHolder<'_> };
-    if !hook.is_null() {
+    if hook.is_not_null() {
         unsafe {
             sideeffect();
             scheduler::save_context_finish_hook(Some(&mut *hook));

--- a/kernel/src/arch/riscv64/trap.rs
+++ b/kernel/src/arch/riscv64/trap.rs
@@ -23,6 +23,7 @@ use crate::{
     support::sideeffect,
     syscalls::{dispatch_syscall, Context as ScContext},
     thread::Thread,
+    types::IsNotNull,
 };
 use core::{
     mem::offset_of,
@@ -185,13 +186,13 @@ extern "C" fn might_switch(from: &Context, to: &Context, mcause: usize) -> usize
     assert_eq!(to_ptr as usize, from.a1);
     let sp = from_ptr as usize;
     let saved_sp_ptr: *mut usize = unsafe { from.a0 as *mut usize };
-    if !saved_sp_ptr.is_null() {
+    if saved_sp_ptr.is_not_null() {
         sideeffect();
         // FIXME: rustc opt the write out if not setting it volatile.
         unsafe { saved_sp_ptr.write_volatile(sp) };
     }
     let hook: *mut ContextSwitchHookHolder = unsafe { from.a2 as *mut ContextSwitchHookHolder };
-    if !hook.is_null() {
+    if hook.is_not_null() {
         sideeffect();
         unsafe {
             scheduler::save_context_finish_hook(Some(&mut *hook));

--- a/kernel/src/types.rs
+++ b/kernel/src/types.rs
@@ -24,6 +24,7 @@ pub use blueos_infra::{
         TinyArcListIterator as ArcListIterator,
     },
     tinyrwlock::{IRwLock, RwLock, RwLockReadGuard, RwLockWriteGuard},
+    IsNotNull,
 };
 use core::marker::PhantomData;
 


### PR DESCRIPTION
We found for developers get used to C-style's `if (ptr)` can easily forget the `!` if writing code `if !ptr.is_null()`. So introduce a new method `is_not_null` for pointer types.