### PR TITLE
Revert "feat: Add check_infra_miri in BUILD.gn (#41)"

### DIFF
--- a/infra/BUILD.gn
+++ b/infra/BUILD.gn
@@ -20,11 +20,6 @@ group("check_infra") {
   deps = [ ":run_infra_unittest" ]
 }
 
-group("check_infra_by_miri") {
-  testonly = true
-  deps = [ ":infra_miri_test($host_miri_toolchain)" ]
-}
-
 shared_deps = [
   "//external/cfg-if/v1.0.0:cfg_if",
   "//external/memchr/v2.7.4:memchr",
@@ -35,11 +30,6 @@ build_rust("blueos_infra") {
   crate_type = "rlib"
   sources = [ "src/lib.rs" ]
   edition = "2021"
-  deps = shared_deps
-}
-
-miri_test("infra_miri_test") {
-  crate = "src/lib.rs"
   deps = shared_deps
 }
 


### PR DESCRIPTION
This reverts commit df205fd03d31c04957e3d94b6152a50642e85f8c.

It currently heavily relies on detecting `miri-sysroot` in `//build/ci/run_ci.py`.

It's blocking developers who are simply using `gn gen ...` manually.