### PR TITLE
Remove copyright automatically added by tools

### DIFF
--- a/kernel/src/sync/libatomic/assembly.h
+++ b/kernel/src/sync/libatomic/assembly.h
@@ -1,17 +1,3 @@
-// Copyright (c) 2025 vivo Mobile Communication Co., Ltd.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//       http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 //===-- assembly.h - compiler-rt assembler support macros -----------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/kernel/src/sync/libatomic/int_endianness.h
+++ b/kernel/src/sync/libatomic/int_endianness.h
@@ -1,17 +1,3 @@
-// Copyright (c) 2025 vivo Mobile Communication Co., Ltd.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//       http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 //===-- int_endianness.h - configuration header for compiler-rt -----------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.


### PR DESCRIPTION
These files don't include changes from vivo, so it's appropriate to remove copyright of vivo.

Thanks @OpenAtomFoundation for pointing it out.