### PR TITLE
Add experimental support of signal

### DIFF
--- a/kernel/src/arch/aarch64/mod.rs
+++ b/kernel/src/arch/aarch64/mod.rs
@@ -437,3 +437,20 @@ pub fn secondary_cpu_setup(psci_base: u32) {
         psci::cpu_on(psci_base, i as usize, crate::boot::_start as usize, 0);
     }
 }
+
+#[naked]
+pub(crate) extern "C" fn switch_stack(
+    to_sp: usize,
+    cont: extern "C" fn(sp: usize, old_sp: usize),
+) -> ! {
+    unsafe {
+        core::arch::naked_asm!(
+            "
+            mov x19, x1
+            mov x1, sp
+            mov sp, x0
+            br x19
+            "
+        )
+    }
+}

--- a/kernel/src/arch/arm/mod.rs
+++ b/kernel/src/arch/arm/mod.rs
@@ -561,3 +561,20 @@ pub extern "C" fn local_irq_enabled() -> bool {
 pub extern "C" fn is_in_interrupt() -> bool {
     cortex_m::peripheral::SCB::vect_active() != cortex_m::peripheral::scb::VectActive::ThreadMode
 }
+
+#[naked]
+pub(crate) extern "C" fn switch_stack(
+    to_sp: usize,
+    cont: extern "C" fn(sp: usize, old_sp: usize),
+) -> ! {
+    unsafe {
+        core::arch::naked_asm!(
+            "
+            mov r12, r1
+            mrs r1, psp
+            msr psp, r0
+            bx r12
+            "
+        )
+    }
+}

--- a/kernel/src/arch/riscv/mod.rs
+++ b/kernel/src/arch/riscv/mod.rs
@@ -502,3 +502,20 @@ pub(crate) extern "C" fn current_cpu_id() -> usize {
     };
     id
 }
+
+#[naked]
+pub(crate) extern "C" fn switch_stack(
+    to_sp: usize,
+    cont: extern "C" fn(sp: usize, old_sp: usize),
+) -> ! {
+    unsafe {
+        core::arch::naked_asm!(
+            "
+            mv t0, a1
+            mv a1, sp
+            mv sp, a0
+            jalr x0, t0, 0
+            "
+        )
+    }
+}

--- a/kernel/src/signal/mod.rs
+++ b/kernel/src/signal/mod.rs
@@ -1,0 +1,56 @@
+// Copyright (c) 2025 vivo Mobile Communication Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::{arch, scheduler, thread, thread::ThreadNode};
+
+fn handle_signal_fallback(signum: i32) {
+    if signum != libc::SIGTERM {
+        return;
+    }
+    scheduler::retire_me();
+}
+
+fn handle_signal(t: &ThreadNode, signum: i32) {
+    let mut l = t.lock();
+    let Some(handler) = l.take_signal_handler(signum) else {
+        drop(l);
+        return handle_signal_fallback(signum);
+    };
+    drop(l);
+    handler();
+}
+
+// This routine is supposed to be executed in THREAD mode.
+#[inline(never)]
+pub(crate) unsafe extern "C" fn handler_entry(_sp: usize, _old_sp: usize) {
+    let current = scheduler::current_thread();
+    let sigset = current.lock().pending_signals();
+    for i in 0..32 {
+        if sigset & (1 << i) == 0 {
+            continue;
+        }
+        handle_signal(&current, i);
+        current.lock().clear_signal(i);
+    }
+    {
+        let mut l = current.lock();
+        l.deactivate_signal_context();
+    }
+    let saved_sp = current.saved_sp();
+    current.transfer_state(thread::RUNNING, thread::READY);
+    let mut hook_holder = scheduler::ContextSwitchHookHolder::new(current);
+    // We are switching from current thread's signal context to its thread
+    // context.
+    arch::restore_context_with_hook(saved_sp, &mut hook_holder as *mut _);
+}


### PR DESCRIPTION
Entering signal context when the thread is re-scheduled and has pending signals. Thread uses the same stack in signal context and the signal handler is run in thread mode. Before entering the signal context, thread context is saved and is restored on exiting of the signal context.