### PR TITLE
Add support of float when eabihf is specified

### DIFF
--- a/kernel/src/boards/qemu_mps3_an547/mod.rs
+++ b/kernel/src/boards/qemu_mps3_an547/mod.rs
@@ -74,7 +74,16 @@ unsafe fn copy_data() {
     INIT_BSS_DONE = true;
 }
 
+unsafe fn enable_fpu() {
+    const SCB_CPACR_PTR: *mut u32 = 0xE000_ED88 as *mut u32;
+    let mut temp = SCB_CPACR_PTR.read_volatile();
+    temp |= 0x00F00000;
+    SCB_CPACR_PTR.write_volatile(temp);
+}
+
 pub(crate) fn init() {
+    unsafe { enable_fpu() };
+
     unsafe {
         copy_data();
     }

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -549,6 +549,26 @@ mod tests {
         }
     }
 
+    #[cfg(target_abi = "eabihf")]
+    #[test]
+    fn test_basic_float_add_sub() {
+        let a: f32 = 1.0;
+        let b = 2.0;
+        let c = 3.0;
+        let epsilon = 1e-6;
+        assert!((a + b - c).abs() <= epsilon);
+    }
+
+    #[cfg(target_abi = "eabihf")]
+    #[test]
+    fn test_basic_float_mul_div() {
+        let a: f32 = 2.0;
+        let b = 3.0;
+        let c = 6.0;
+        let epsilon = 1e-6;
+        assert!((a * b / c - 1.0).abs() <= epsilon);
+    }
+
     #[inline(never)]
     pub fn kernel_unittest_runner(tests: &[&dyn Fn()]) {
         let t = scheduler::current_thread();


### PR DESCRIPTION
Also adjust handling of syscall on cortex-m platform, so that floating point context is handled correctly.