### PR TITLE
Make predicate of step 'notify' the same as step 'setup'

### DIFF
--- a/.github/workflows/reusable_cross_repos_build.yml
+++ b/.github/workflows/reusable_cross_repos_build.yml
@@ -430,7 +430,7 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     needs: [setup, check_format, check_license, build_host, build_and_check_virtual_boards]
-    if: always()
+    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, 'build_prs') }}
     permissions:
       contents: read
       checks: write


### PR DESCRIPTION
To avoid false alarm like https://github.com/vivoblueos/librs/actions/runs/18966674094.