### PR TITLE
Fix missing error report on failure

### DIFF
--- a/.github/workflows/reusable_cross_repos_build.yml
+++ b/.github/workflows/reusable_cross_repos_build.yml
@@ -427,7 +427,6 @@ jobs:
                 console.error(`❌ ${profile} build failed:`, error.message);
                 process.exit(1);
             }
-
   notify:
     runs-on: ubuntu-latest
     needs: [setup, check_format, check_license, build_host, build_and_check_virtual_boards]


### PR DESCRIPTION
After https://github.com/vivoblueos/kernel/commit/1b5f329fe0ccddc9222d142dbaf26b5403f03155, we are unable to see error report on failure.

For the POC of this fix, please check:
On failure, https://github.com/lawkai-vivo/kernel/pull/5#issuecomment-3489623590, https://github.com/lawkai-vivo/kernel/pull/5#issuecomment-3489624597.
On being skipped, https://github.com/lawkai-vivo/kernel/pull/5#issuecomment-3489625246, https://github.com/lawkai-vivo/kernel/actions/runs/19093680042.