### PR TITLE
Fix shell syntax error

### DIFF
--- a/.github/workflows/reusable_cross_repos_build.yml
+++ b/.github/workflows/reusable_cross_repos_build.yml
@@ -100,7 +100,7 @@ jobs:
           for patch in patches/*.patch; do
             patch_abspath=$(realpath ${patch})
             repo=$(basename ${patch} ".patch")
-            if [ "${repo}" == "manifests" ]; then
+            if [ "${repo}" = "manifests" ]; then
               continue
             fi
             repo_path=$(repo list ${repo} | cut -d ':' -f 1)


### PR DESCRIPTION
Reported in https://github.com/vivoblueos/external/actions/runs/19357934703/job/55382851561
```
/__w/_temp/c86bda40-9cbf-4343-9d82-4cb809aa2958.sh: 6: [: manifests: unexpected operator
```