### PR TITLE
Rename thread::CREATED to thread::IDLE

### DIFF
--- a/adapter/cmsis/src/common_objects.rs
+++ b/adapter/cmsis/src/common_objects.rs
@@ -131,7 +131,7 @@ mod tests {
         // 1 in global queue, 1 in os_thread, 1 in ready queue
         // total 3, drop one reference here
         drop(os_thread);
-        scheduler::queue_ready_thread(thread::CREATED, thread);
+        scheduler::queue_ready_thread(thread::IDLE, thread);
         scheduler::yield_me(); // to retire the thread
     }
 
@@ -143,7 +143,7 @@ mod tests {
         // 1 in global queue, 1 in os_thread, 1 in ready queue
         // total 3, drop one reference here
         drop(os_thread);
-        scheduler::queue_ready_thread(thread::CREATED, thread);
+        scheduler::queue_ready_thread(thread::IDLE, thread);
         scheduler::yield_me(); // to retire the thread
     }
 }

--- a/adapter/cmsis/src/os2/thread.rs
+++ b/adapter/cmsis/src/os2/thread.rs
@@ -78,7 +78,7 @@ impl Os2Thread {
 #[inline(always)]
 pub fn to_os_state(state: u8) -> osThreadState_t {
     match state as Uint {
-        thread::CREATED => osThreadState_t_osThreadInactive,
+        thread::IDLE => osThreadState_t_osThreadInactive,
         thread::READY => osThreadState_t_osThreadReady,
         thread::RUNNING => osThreadState_t_osThreadRunning,
         thread::SUSPENDED => osThreadState_t_osThreadBlocked,
@@ -91,7 +91,7 @@ pub fn to_os_state(state: u8) -> osThreadState_t {
 #[inline(always)]
 pub fn to_thread_state(state: osThreadState_t) -> u8 {
     match state {
-        osThreadState_t_osThreadInactive => thread::CREATED as u8,
+        osThreadState_t_osThreadInactive => thread::IDLE as u8,
         osThreadState_t_osThreadReady => thread::READY as u8,
         osThreadState_t_osThreadRunning => thread::RUNNING as u8,
         osThreadState_t_osThreadBlocked => thread::SUSPENDED as u8,

--- a/adapter/thread_metric/src/lib.rs
+++ b/adapter/thread_metric/src/lib.rs
@@ -16,7 +16,7 @@
 
 use blueos::{
     scheduler, thread,
-    thread::{Entry, Thread, ThreadNode, CREATED, READY, RUNNING, SUSPENDED},
+    thread::{Entry, Thread, ThreadNode, IDLE, READY, RUNNING, SUSPENDED},
     time,
     types::{Arc, ThreadPriority},
 };
@@ -71,8 +71,7 @@ pub extern "C" fn tm_thread_create(
 pub extern "C" fn tm_thread_resume(thread_id: c_int) -> c_int {
     let t = unsafe { TM_THREADS[thread_id as usize].assume_init_ref().clone() };
     // Resuming myself should not happen.
-    if scheduler::queue_ready_thread(SUSPENDED, t.clone())
-        || scheduler::queue_ready_thread(CREATED, t)
+    if scheduler::queue_ready_thread(SUSPENDED, t.clone()) || scheduler::queue_ready_thread(IDLE, t)
     {
         scheduler::relinquish_me();
         return TM_SUCCESS;

--- a/kernel/src/asynk/mod.rs
+++ b/kernel/src/asynk/mod.rs
@@ -71,11 +71,11 @@ pub(crate) fn init() {
         unsafe { &mut POLLER },
         unsafe { &mut POLLER_STORAGE },
         MAX_THREAD_PRIORITY,
-        thread::CREATED,
+        thread::IDLE,
         Entry::C(poll),
         ThreadKind::AsyncPoller,
     );
-    let ok = scheduler::queue_ready_thread(thread::CREATED, poller);
+    let ok = scheduler::queue_ready_thread(thread::IDLE, poller);
     debug_assert!(ok);
 }
 

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -187,7 +187,7 @@ mod tests {
             unsafe { &mut TEST_THREADS[i] },
             unsafe { &mut TEST_THREAD_STORAGES[i] },
             config::MAX_THREAD_PRIORITY / 2,
-            thread::CREATED,
+            thread::IDLE,
             Entry::C(test_main),
             ThreadKind::Normal,
         );
@@ -202,11 +202,11 @@ mod tests {
             unsafe { &mut MAIN_THREAD },
             unsafe { &mut MAIN_THREAD_STORAGE },
             config::MAX_THREAD_PRIORITY / 2,
-            thread::CREATED,
+            thread::IDLE,
             Entry::C(test_main),
             ThreadKind::Normal,
         );
-        let ok = scheduler::queue_ready_thread(thread::CREATED, t.clone());
+        let ok = scheduler::queue_ready_thread(thread::IDLE, t.clone());
         assert!(ok);
     }
 

--- a/kernel/src/syscall_handlers/mod.rs
+++ b/kernel/src/syscall_handlers/mod.rs
@@ -383,7 +383,7 @@ create_thread(spawn_args_ptr: *const SpawnArgs) -> c_long {
     };
     let handle = Thread::id(&t);
     if let Some(f) = spawn_args.spawn_hook { f(handle, spawn_args_ptr as *mut _); }
-    let ok = scheduler::queue_ready_thread(thread::CREATED, t);
+    let ok = scheduler::queue_ready_thread(thread::IDLE, t);
     // We don't increment the rc of the created thread since it's also
     // referenced by the global queue. When this thread is retired,
     // it's removed from the global queue.

--- a/kernel/src/thread/builder.rs
+++ b/kernel/src/thread/builder.rs
@@ -95,7 +95,7 @@ where
     let entry = Box::new(f);
     let builder = Builder::new(Entry::Closure(entry));
     let t = builder.build();
-    if scheduler::queue_ready_thread(thread::CREATED, t.clone()) {
+    if scheduler::queue_ready_thread(thread::IDLE, t.clone()) {
         return Some(t);
     }
     None
@@ -151,7 +151,7 @@ impl Builder {
 
     pub fn start(self) -> ThreadNode {
         let t = self.build();
-        let ok = scheduler::queue_ready_thread(super::CREATED, t.clone());
+        let ok = scheduler::queue_ready_thread(super::IDLE, t.clone());
         debug_assert!(ok);
         // TODO: Invoke yield_me_now_or_later for better realtime performance. However
         // this breaks some existed tests and need TBI.
@@ -209,7 +209,7 @@ pub(crate) fn build_static_thread(
     w.set_origin_priority(p);
     w.set_priority(p);
     w.set_kind(kind);
-    debug_assert!((thread::CREATED..=thread::RETIRED).contains(&init_state));
+    debug_assert!((thread::IDLE..=thread::RETIRED).contains(&init_state));
     unsafe { w.set_state(init_state) };
     debug!(
         "System thread 0x{:x} created: sp: 0x{:x}, stack base: {:?}, stack size: {}, context size: {}",

--- a/kernel/src/thread/mod.rs
+++ b/kernel/src/thread/mod.rs
@@ -89,10 +89,15 @@ impl_simple_intrusive_adapter!(OffsetOfSchedNode, Thread, sched_node);
 impl_simple_intrusive_adapter!(OffsetOfGlobal, Thread, global);
 impl_simple_intrusive_adapter!(OffsetOfLock, Thread, lock);
 
-pub const CREATED: Uint = 0;
+// When a thread is created or is removed from the RQ.
+pub const IDLE: Uint = 0;
+// When a thread is added to a RQ.
 pub const READY: Uint = 1;
+// When a thread is running.
 pub const RUNNING: Uint = 2;
+// When a thread is suspended.
 pub const SUSPENDED: Uint = 3;
+// When a thread is retired.
 pub const RETIRED: Uint = 4;
 
 // ThreadStats is protected by thread scheduler.
@@ -272,7 +277,7 @@ impl Thread {
     pub fn state_to_str(&self) -> &str {
         let state = self.state.load(Ordering::Relaxed);
         match state {
-            CREATED => "created",
+            IDLE => "idle",
             READY => "ready",
             RUNNING => "running",
             SUSPENDED => "suspended",
@@ -384,7 +389,7 @@ impl Thread {
         Self {
             cleanup: None,
             stack: Stack::new(),
-            state: AtomicUint::new(CREATED),
+            state: AtomicUint::new(IDLE),
             lock: ISpinLock::new(),
             sched_node: IlistHead::<Thread, OffsetOfSchedNode>::new(),
             global: UniqueListHead::new(),

--- a/kernel/src/time/timer.rs
+++ b/kernel/src/time/timer.rs
@@ -69,12 +69,12 @@ pub fn system_timer_init() {
             unsafe { &mut SOFT_TIMER_THREAD },
             unsafe { &mut SOFT_TIMER_THREAD_STACK },
             config::SOFT_TIMER_THREAD_PRIORITY,
-            thread::CREATED,
+            thread::IDLE,
             Entry::C(run_soft_timer),
             ThreadKind::SoftTimer,
         );
         unsafe { SOFT_TIMER_THREAD.write(th.clone()) };
-        let ok = scheduler::queue_ready_thread(thread::CREATED, th);
+        let ok = scheduler::queue_ready_thread(thread::IDLE, th);
         debug_assert!(ok);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/vivoblueos/kernel/issues/164