### PR TITLE
Remove const_new API

### DIFF
--- a/adapter/cmsis/src/os2/event_flags.rs
+++ b/adapter/cmsis/src/os2/event_flags.rs
@@ -76,7 +76,7 @@ pub extern "C" fn osEventFlagsNew(attr: *const osEventFlagsAttr_t) -> osEventFla
     unsafe {
         ptr::write(
             attr_ref.cb_mem as *mut ArcInner<OsEventFlags>,
-            ArcInner::const_new(OsEventFlags::with_name(event_flags, attr_ref.name)),
+            ArcInner::new(OsEventFlags::with_name(event_flags, attr_ref.name)),
         )
     };
     let os_event = unsafe { Arc::from_raw(attr_ref.cb_mem as *mut _ as *mut OsEventFlags) };

--- a/adapter/cmsis/src/os2/semaphore.rs
+++ b/adapter/cmsis/src/os2/semaphore.rs
@@ -73,7 +73,7 @@ pub extern "C" fn osSemaphoreNew(
     unsafe {
         ptr::write(
             attr_ref.cb_mem as *mut ArcInner<OsSemaphore>,
-            ArcInner::const_new(OsSemaphore::with_name(semaphore, attr_ref.name)),
+            ArcInner::new(OsSemaphore::with_name(semaphore, attr_ref.name)),
         )
     };
     let os_sem = unsafe { Arc::from_raw(attr_ref.cb_mem as *mut _ as *mut OsSemaphore) };

--- a/adapter/cmsis/src/os2/timer.rs
+++ b/adapter/cmsis/src/os2/timer.rs
@@ -96,7 +96,7 @@ pub extern "C" fn osTimerNew(
     unsafe {
         ptr::write(
             attr_ref.cb_mem as *mut ArcInner<OsTimer>,
-            ArcInner::const_new(OsTimer::with_name(timer, attr_ref.name)),
+            ArcInner::new(OsTimer::with_name(timer, attr_ref.name)),
         )
     };
     let os_timer = unsafe { Arc::from_raw(attr_ref.cb_mem as *mut _ as *mut OsTimer) };

--- a/infra/src/list/typed_ilist.rs
+++ b/infra/src/list/typed_ilist.rs
@@ -91,10 +91,6 @@ impl<T, A: Adapter<T>> Iterator for ListReverseIterator<T, A> {
 
 impl<T, A: Adapter<T>> ListHead<T, A> {
     pub const fn new() -> Self {
-        Self::const_new()
-    }
-
-    pub const fn const_new() -> Self {
         Self {
             prev: None,
             next: None,

--- a/infra/src/spinarc.rs
+++ b/infra/src/spinarc.rs
@@ -53,7 +53,7 @@ impl<T> IlistNode<T> {
         self
     }
 
-    pub const unsafe fn const_new(object: &'static T) -> Self {
+    pub const unsafe fn from_static(object: &'static T) -> Self {
         Self {
             version: 0,
             prev: None,

--- a/infra/src/tinyrwlock.rs
+++ b/infra/src/tinyrwlock.rs
@@ -824,16 +824,12 @@ pub struct IRwLock<T: Sized, A: Adapter<T>> {
 }
 
 impl<T: Sized, A: Adapter<T>> IRwLock<T, A> {
-    pub const fn const_new() -> Self {
+    pub const fn new() -> Self {
         Self {
             rwlock: RwLock::new(()),
             _t: PhantomData,
             _a: PhantomData,
         }
-    }
-
-    pub const fn new() -> Self {
-        Self::const_new()
     }
 
     #[inline]

--- a/kernel/src/scheduler/wait_queue.rs
+++ b/kernel/src/scheduler/wait_queue.rs
@@ -78,15 +78,11 @@ pub(crate) struct WaitQueueGuardDropper<'a, const N: usize> {
 }
 
 impl<'a, const N: usize> WaitQueueGuardDropper<'a, N> {
-    pub const fn const_new() -> Self {
+    pub const fn new() -> Self {
         Self {
             guards: [const { None }; N],
             num_active_guards: 0,
         }
-    }
-
-    pub const fn new() -> Self {
-        Self::const_new()
     }
 
     #[inline]

--- a/kernel/src/sync/semaphore.rs
+++ b/kernel/src/sync/semaphore.rs
@@ -31,15 +31,11 @@ pub struct Semaphore {
 }
 
 impl Semaphore {
-    pub const fn const_new() -> Self {
+    pub const fn new() -> Self {
         Self {
             counter: Cell::new(1),
             pending: SpinLock::new(WaitQueue::new()),
         }
-    }
-
-    pub const fn new() -> Self {
-        Self::const_new()
     }
 
     pub fn init(&self, counter: Uint) -> bool {

--- a/kernel/src/sync/spinlock.rs
+++ b/kernel/src/sync/spinlock.rs
@@ -82,14 +82,10 @@ impl<'a, T: 'a + ?Sized> Deref for SpinLockReadGuard<'a, T> {
 }
 
 impl<T> SpinLock<T> {
-    pub const fn const_new(val: T) -> Self {
+    pub const fn new(val: T) -> Self {
         Self {
             lock: RwLock::new(val),
         }
-    }
-
-    pub const fn new(val: T) -> Self {
-        Self::const_new(val)
     }
 }
 

--- a/kernel/src/thread/builder.rs
+++ b/kernel/src/thread/builder.rs
@@ -159,17 +159,13 @@ pub(crate) struct SystemThreadStorage {
 }
 
 impl SystemThreadStorage {
-    pub(crate) const fn const_new(kind: ThreadKind) -> Self {
+    pub(crate) const fn new(kind: ThreadKind) -> Self {
         Self {
             arc: ArcInner::<Thread>::new(Thread::new(kind)),
             stack: SystemThreadStack {
                 rep: [0u8; SYSTEM_THREAD_STACK_SIZE],
             },
         }
-    }
-
-    pub(crate) const fn new(kind: ThreadKind) -> Self {
-        Self::const_new(kind)
     }
 }
 
@@ -185,7 +181,7 @@ pub(crate) fn build_static_thread(
 ) -> ThreadNode {
     let inner = &s.arc;
     let stack = &mut s.stack;
-    let arc = unsafe { ThreadNode::const_new(inner) };
+    let arc = unsafe { ThreadNode::from_static_inner_ref(inner) };
     debug_assert_eq!(ThreadNode::strong_count(&arc), 1);
     let _id = Thread::id(&arc);
     let mut w = arc.lock();

--- a/kernel/src/thread/mod.rs
+++ b/kernel/src/thread/mod.rs
@@ -338,10 +338,6 @@ impl Thread {
         self
     }
 
-    const fn new(kind: ThreadKind) -> Self {
-        Self::const_new(kind)
-    }
-
     #[inline]
     pub fn take_cleanup(&mut self) -> Option<Entry> {
         self.cleanup.take()
@@ -380,7 +376,7 @@ impl Thread {
         self.pending_on_mutex.swap(mu, Ordering::Release)
     }
 
-    const fn const_new(kind: ThreadKind) -> Self {
+    const fn new(kind: ThreadKind) -> Self {
         Self {
             cleanup: None,
             stack: Stack::new(),

--- a/kernel/src/time/timer.rs
+++ b/kernel/src/time/timer.rs
@@ -30,14 +30,14 @@ use thread::{Entry, SystemThreadStorage, Thread, ThreadKind, ThreadNode};
 
 const TIMER_WHEEL_SIZE: u32 = 32;
 
-static HARD_TIMER_WHEEL: TimerWheel = TimerWheel::const_new();
+static HARD_TIMER_WHEEL: TimerWheel = TimerWheel::new();
 #[cfg(soft_timer)]
-static SOFT_TIMER_WHEEL: TimerWheel = TimerWheel::const_new();
+static SOFT_TIMER_WHEEL: TimerWheel = TimerWheel::new();
 #[cfg(soft_timer)]
 static mut SOFT_TIMER_THREAD: MaybeUninit<ThreadNode> = MaybeUninit::zeroed();
 #[cfg(soft_timer)]
 static mut SOFT_TIMER_THREAD_STACK: SystemThreadStorage =
-    SystemThreadStorage::const_new(ThreadKind::SoftTimer);
+    SystemThreadStorage::new(ThreadKind::SoftTimer);
 
 #[cfg(soft_timer)]
 extern "C" fn run_soft_timer() {
@@ -95,11 +95,9 @@ struct TimerWheel {
 unsafe impl Sync for TimerWheel {}
 
 impl TimerWheel {
-    const fn const_new() -> Self {
+    const fn new() -> Self {
         Self {
-            wheel: SpinLock::const_new(
-                [const { WheelTimerList::const_new() }; TIMER_WHEEL_SIZE as usize],
-            ),
+            wheel: SpinLock::new([const { WheelTimerList::new() }; TIMER_WHEEL_SIZE as usize]),
         }
     }
 

--- a/kernel/src/types.rs
+++ b/kernel/src/types.rs
@@ -57,8 +57,8 @@ macro_rules! static_arc {
         mod $name {
             use super::*;
             use $crate::types::{Arc, ArcInner};
-            static CTRL_BLOCK: ArcInner<$ty> = ArcInner::const_new($val);
-            pub(super) static PTR: Arc<$ty> = unsafe { Arc::const_new(&CTRL_BLOCK) };
+            static CTRL_BLOCK: ArcInner<$ty> = ArcInner::new($val);
+            pub(super) static PTR: Arc<$ty> = unsafe { Arc::from_static_inner_ref(&CTRL_BLOCK) };
         }
         use $name::PTR as $name;
     };


### PR DESCRIPTION
If `new` and `const_new` are different, `const_new` is renamed.