### PR TITLE
Modify FLASH size of gd32e507_eval in debug mode

### DIFF
--- a/kconfig/config/gd32e507_eval/debug/defconfig
+++ b/kconfig/config/gd32e507_eval/debug/defconfig
@@ -36,4 +36,10 @@ CONFIG_SRAM_BASE_ADDRESS=0x20000000
 CONFIG_SRAM_SIZE=128
 CONFIG_STACK_SIZE=16
 CONFIG_FLASH_BASE_ADDRESS=0x08000000
+# Fixme: In fact, the GD32E507's flash size 
+# cannot exceed 512 KB. Here it is set to 
+# 1024 KB — exceeding the actual hardware limit — to allow 
+# the firmware to compile so the emulator can run it for debugging. 
+# Note: the GD32E507 firmware built in debug mode will 
+# not run on real hardware
 CONFIG_FLASH_SIZE=1024


### PR DESCRIPTION
In fact, the GD32E507's flash size cannot exceed 512 KB. Here it is set to 1024 KB — exceeding the actual hardware limit — to allow the firmware to compile so the emulator can run it for debugging. 

Note: the GD32E507 firmware built in debug mode will not run on real hardware