### PR TITLE
Use Storage to replace Box[u8]

### DIFF
--- a/infra/src/storage.rs
+++ b/infra/src/storage.rs
@@ -81,3 +81,7 @@ impl Drop for Storage {
         }
     }
 }
+
+// FIXME: Workaround for pointer based storage.
+unsafe impl Send for Storage {}
+unsafe impl Sync for Storage {}


### PR DESCRIPTION
Avoid double free when we're using FFI in adapters.