### PR TITLE
Mask mcause for valid bits

### DIFF
--- a/kernel/src/arch/riscv/trap.rs
+++ b/kernel/src/arch/riscv/trap.rs
@@ -228,7 +228,7 @@ fn might_switch_context(from: &Context, ra: usize) -> usize {
 extern "C" fn handle_trap(ctx: &mut Context, mcause: usize, mtval: usize, cont: usize) -> usize {
     debug_assert!(!super::local_irq_enabled());
     let sp = ctx as *const _ as usize;
-    match mcause & 0x8000_000f {
+    match mcause & (INTERRUPT_MASK | 0x3f) {
         EXTERN_INT => {
             handle_plic_irq(ctx, mcause, mtval);
             might_switch_context(ctx, cont)


### PR DESCRIPTION
The MCAUSE register only has bit 31 and bits [4:0] (or [3:0]) defined as valid in common; the other bits might be used in certain soc, and are not guaranteed to be zero.

See: https://docs.amd.com/r/en-US/ug1629-microblaze-v-user-guide/Machine-Cause-Register-mcause