### PR TITLE
Init global pointer when launching a new thread

### DIFF
--- a/kernel/src/arch/riscv/mod.rs
+++ b/kernel/src/arch/riscv/mod.rs
@@ -441,13 +441,18 @@ pub(crate) struct IsrContext {
 impl Context {
     #[inline]
     pub(crate) fn init(&mut self) -> &mut Self {
+        self.gp = Self::__global_pointer();
+        self
+    }
+
+    #[inline]
+    pub(crate) fn __global_pointer() -> usize {
         let gp_val: usize;
         unsafe {
             core::arch::asm!("la {}, __global_pointer$", out(reg) gp_val,
                              options(nostack, nomem))
         }
-        self.gp = gp_val;
-        self
+        gp_val
     }
 
     // We are following C-ABI, since Rust ABI is not stablized.

--- a/kernel/src/drivers/sensor/bme280.rs
+++ b/kernel/src/drivers/sensor/bme280.rs
@@ -33,7 +33,7 @@ impl DelayNs for KernelDelay {
         if ticks == 0 {
             scheduler::yield_me();
         } else {
-            // scheduler::suspend_me_for(ticks as _);
+            scheduler::suspend_me_for(ticks as _);
         }
     }
 }


### PR DESCRIPTION
Failure to preserve the gp register during context creation can lead to undefined behavior when switching to a new thread context.