### PR TITLE
Fix incorrect state transfer when preemption is disabled

### DIFF
--- a/kernel/src/arch/riscv/mod.rs
+++ b/kernel/src/arch/riscv/mod.rs
@@ -58,6 +58,9 @@ pub(crate) extern "C" fn pend_switch_context() {
 
 #[inline]
 pub(crate) extern "C" fn claim_switch_context() -> bool {
+    if !scheduler::current_thread_ref().is_preemptable() {
+        return false;
+    }
     let level = disable_local_irq_save();
     let id = current_cpu_id();
     let ok = unsafe { PENDING_SWITCH_CONTEXT[id].get() };


### PR DESCRIPTION
Consider following function call chain in rv32

0. yield_me_now_or_later
1. suspend_me
2. disable_preempt
3. timer interrupt occurs
4. claim pending switch and switch to another thread

So check is_preemptable in yield_me_now_or_later is invalid. We should check it when we are really deciding to switch or not.

Fixes https://github.com/vivoblueos/kernel/issues/299.