### PR TITLE
Fix memory leak in test of TinyArcSortedList

### DIFF
--- a/infra/src/tinyarc/sorted_list.rs
+++ b/infra/src/tinyarc/sorted_list.rs
@@ -488,7 +488,7 @@ mod tests {
             priorities.push(task.priority);
         }
         assert_eq!(priorities, vec![3, 5, 8]);
-        while let Some(_) = list.pop_front() {}
+        while list.pop_front().is_some() {}
     }
 
     #[test]
@@ -559,6 +559,6 @@ mod tests {
         // Verify removal
         assert_eq!(list.len(), 2);
         assert!(list.find(|t| t.id == 2).is_none());
-        while let Some(_) = list.pop_front() {}
+        while list.pop_front().is_some() {}
     }
 }


### PR DESCRIPTION
```
==1650645== HEAP SUMMARY:
==1650645==     in use at exit: 200 bytes in 5 blocks
==1650645==   total heap usage: 787,748 allocs, 787,743 frees, 34,762,343 bytes allocated
==1650645==
==1650645== 80 (40 direct, 40 indirect) bytes in 1 blocks are definitely lost in loss record 4 of 5
==1650645==    at 0x48417B4: malloc (vg_replace_malloc.c:381)
==1650645==    by 0x19ED97: alloc::alloc::exchange_malloc (in /build/vivoblueos/out/none.release/bin/infra_unittest)
==1650645==    by 0x19EE00: infra_unittest::tinyarc::TinyArc<T>::new (in /build/vivoblueos/out/none.release/bin/infra_unittest)
==1650645==    by 0x19F715: infra_unittest::tinyarc::sorted_list::tests::test_find_and_remove (in /build/vivoblueos/out/none.release/bin/infra_unittest)
==1650645==    by 0x193E2A: core::ops::function::FnOnce::call_once (in /build/vivoblueos/out/none.release/bin/infra_unittest)
==1650645==    by 0x1DA0CA: test::__rust_begin_short_backtrace (in /build/vivoblueos/out/none.release/bin/infra_unittest)
==1650645==    by 0x1CDCA1: test::types::RunnableTest::run (in /build/vivoblueos/out/none.release/bin/infra_unittest)
==1650645==    by 0x1DA281: test::run_test_in_process (in /build/vivoblueos/out/none.release/bin/infra_unittest)
==1650645==    by 0x1C2239: std::sys::backtrace::__rust_begin_short_backtrace (in /build/vivoblueos/out/none.release/bin/infra_unittest)
==1650645==    by 0x1B2C5E: core::ops::function::FnOnce::call_once{{vtable.shim}} (in /build/vivoblueos/out/none.release/bin/infra_unittest)
==1650645==    by 0x22968C: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once (in /build/vivoblueos/out/none.release/bin/infra_unittest)
==1650645==    by 0x22D399: std::sys::pal::unix::thread::Thread::new::thread_start (in /build/vivoblueos/out/none.release/bin/infra_unittest)
==1650645==
==1650645== 120 (40 direct, 80 indirect) bytes in 1 blocks are definitely lost in loss record 5 of 5
==1650645==    at 0x48417B4: malloc (vg_replace_malloc.c:381)
==1650645==    by 0x19ED97: alloc::alloc::exchange_malloc (in /build/vivoblueos/out/none.release/bin/infra_unittest)
==1650645==    by 0x19EE00: infra_unittest::tinyarc::TinyArc<T>::new (in /build/vivoblueos/out/none.release/bin/infra_unittest)
==1650645==    by 0x19F07A: infra_unittest::tinyarc::sorted_list::tests::test_basic_functionality (in /build/vivoblueos/out/none.release/bin/infra_unittest)
==1650645==    by 0x1949A8: core::ops::function::FnOnce::call_once (in /build/vivoblueos/out/none.release/bin/infra_unittest)
==1650645==    by 0x1DA0CA: test::__rust_begin_short_backtrace (in /build/vivoblueos/out/none.release/bin/infra_unittest)
==1650645==    by 0x1CDCA1: test::types::RunnableTest::run (in /build/vivoblueos/out/none.release/bin/infra_unittest)
==1650645==    by 0x1DA281: test::run_test_in_process (in /build/vivoblueos/out/none.release/bin/infra_unittest)
==1650645==    by 0x1C2239: std::sys::backtrace::__rust_begin_short_backtrace (in /build/vivoblueos/out/none.release/bin/infra_unittest)
==1650645==    by 0x1B2C5E: core::ops::function::FnOnce::call_once{{vtable.shim}} (in /build/vivoblueos/out/none.release/bin/infra_unittest)
==1650645==    by 0x22968C: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once (in /build/vivoblueos/out/none.release/bin/infra_unittest)
==1650645==    by 0x22D399: std::sys::pal::unix::thread::Thread::new::thread_start (in /build/vivoblueos/out/none.release/bin/infra_unittest)
==1650645==
==1650645== LEAK SUMMARY:
==1650645==    definitely lost: 80 bytes in 2 blocks
==1650645==    indirectly lost: 120 bytes in 3 blocks
```