### PR TITLE
Make MIE optional

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -48,3 +48,11 @@ if ROMSTART_RELOCATION
 		  Size of the region in KB.
 
 endif
+
+config RISCV
+    bool "RISC-V"
+    default n
+
+if RISCV
+    rsource "riscv/Kconfig"
+endif

--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -1,0 +1,23 @@
+# RISC-V Configuration
+
+menu "RISCV Configuration"
+
+config HAS_PLIC
+    bool "PLIC supports"
+    default n
+    help
+      Whether the platform supports the PLIC.
+
+config HAS_CLIC
+    bool "CLIC supports"
+    default n
+    help
+      Whether the platform supports the CLIC.
+
+config HAS_MIE
+    bool "MIE supports"
+    default n
+    help
+      Whether the platform supports the MIE.
+      
+endmenu

--- a/kconfig/BUILD.gn
+++ b/kconfig/BUILD.gn
@@ -24,6 +24,7 @@ _kconfig_files = [
   "//kernel/kernel/src/scheduler/Kconfig",
   "//kernel/kernel/src/vfs/Kconfig",
   "//kernel/kernel/src/net/Kconfig",
+  "//kernel/arch/riscv/Kconfig",
 ]
 
 _config_file = rebase_path("${root_gen_dir}/.config")

--- a/kernel/src/arch/riscv/mod.rs
+++ b/kernel/src/arch/riscv/mod.rs
@@ -481,12 +481,21 @@ impl Context {
 }
 
 pub(crate) extern "C" fn bootstrap() {
+    #[cfg(has_mie)]
     unsafe {
         core::arch::asm!(
             "csrs mstatus, {mstatus}",
             "csrs mie, {mie}",
             mstatus = in(reg) MSTATUS_MPP_M | MSTATUS_MPIE,
             mie = in(reg) MIE_MTIE|MIE_MSIE|MIE_MEIE,
+            options(nostack),
+        )
+    };
+    #[cfg(not(has_mie))]
+    unsafe {
+        core::arch::asm!(
+            "csrs mstatus, {mstatus}",
+            mstatus = in(reg) MSTATUS_MPP_M | MSTATUS_MPIE,
             options(nostack),
         )
     };

--- a/kernel/src/boards/gd32vw553_eval/Kconfig
+++ b/kernel/src/boards/gd32vw553_eval/Kconfig
@@ -1,0 +1,6 @@
+config SOC_GD32VW553
+    bool "Gd32vw553"
+    default y
+    select RISCV
+    select HAS_MIE
+    select HAS_PLIC

--- a/kernel/src/boards/qemu_riscv32/Kconfig
+++ b/kernel/src/boards/qemu_riscv32/Kconfig
@@ -18,3 +18,10 @@ choice
         help
           Set irq priority bits to 8.
 endchoice
+
+config SOC_QEMU_VIRT_RISCV32
+    bool "Qemu Virt Riscv32"
+    default y
+    select RISCV
+    select HAS_MIE
+    select HAS_PLIC

--- a/kernel/src/boards/qemu_riscv64/Kconfig
+++ b/kernel/src/boards/qemu_riscv64/Kconfig
@@ -18,3 +18,10 @@ choice
         help
           Set irq priority bits to 8.
 endchoice
+
+config SOC_QEMU_VIRT_RISCV64
+    bool "Qemu Virt Riscv64"
+    default y
+    select RISCV
+    select HAS_MIE
+    select HAS_PLIC


### PR DESCRIPTION
MIE register is not always available in Riscv arch. So make it optional.