### PR TITLE
Thread being retired should not be preempted

### DIFF
--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -174,6 +174,7 @@ mod tests {
     ) {
         unsafe {
             let t = TEST_THREADS[i].assume_init_ref();
+            t.set_preempt_count(0);
             let mut w = t.lock();
             let stack = &mut TEST_THREAD_STORAGES[i].stack;
             let Some(stack) = thread::Stack::from_raw(stack.rep.as_mut_ptr(), stack.rep.len())

--- a/kernel/src/scheduler/mod.rs
+++ b/kernel/src/scheduler/mod.rs
@@ -231,7 +231,6 @@ fn switch_current_thread(next: ThreadNode, old_sp: usize) -> usize {
     #[cfg(thread_stats)]
     old.increment_cycles(cycles);
     if old.state() == thread::RETIRED {
-        old.enable_preempt();
         GlobalQueueVisitor::remove(&mut old);
         if ThreadNode::strong_count(&old) != 1 {
             // TODO: Add warning log that there are still references to the old thread.

--- a/kernel/src/thread/mod.rs
+++ b/kernel/src/thread/mod.rs
@@ -634,6 +634,11 @@ impl Thread {
         self.preempt_count.load(Ordering::Acquire)
     }
 
+    pub unsafe fn set_preempt_count(&self, val: Uint) -> &Self {
+        self.preempt_count.store(val, Ordering::Release);
+        self
+    }
+
     #[cfg(thread_stats)]
     #[inline]
     pub fn increment_cycles(&self, cycles: u64) {


### PR DESCRIPTION
Fix https://github.com/vivoblueos/kernel/actions/runs/22700766319/job/65817293534.
```
panicked at ../../kernel/kernel/src/scheduler/mod.rs:269:9:
assertion `left == right` failed
  left: Err(4)
 right: Ok(())
Oops: assertion `left == right` failed
```