### PR TITLE
fix(time): avoid multiplication overflow in from_clock_cycles

### DIFF
--- a/kernel/src/time.rs
+++ b/kernel/src/time.rs
@@ -66,8 +66,8 @@ impl Tick {
         debug_assert_eq!(ClockImpl::hz() % TICKS_PER_SECOND as u64, 0);
         // Use u128 to avoid multiplication overflow when cycles is large
         Self(
-            (ClockImpl::estimate_current_cycles() as u128 * TICKS_PER_SECOND as u128 / ClockImpl::hz() as u128)
-                as usize,
+            (ClockImpl::estimate_current_cycles() as u128 * TICKS_PER_SECOND as u128
+                / ClockImpl::hz() as u128) as usize,
         )
     }
 
@@ -83,7 +83,9 @@ impl Tick {
             return;
         }
         // Use u128 to avoid multiplication overflow when n is large
-        ClockImpl::interrupt_at((ClockImpl::hz() as u128 * n.0 as u128 / TICKS_PER_SECOND as u128) as u64);
+        ClockImpl::interrupt_at(
+            (ClockImpl::hz() as u128 * n.0 as u128 / TICKS_PER_SECOND as u128) as u64,
+        );
     }
 }
 

--- a/kernel/src/time.rs
+++ b/kernel/src/time.rs
@@ -64,11 +64,8 @@ impl Tick {
 
     pub fn now() -> Self {
         debug_assert_eq!(ClockImpl::hz() % TICKS_PER_SECOND as u64, 0);
-        // Use u128 to avoid multiplication overflow when cycles is large
-        Self(
-            (ClockImpl::estimate_current_cycles() as u128 * TICKS_PER_SECOND as u128
-                / ClockImpl::hz() as u128) as usize,
-        )
+        let cycles_per_tick = ClockImpl::hz() / TICKS_PER_SECOND as u64;
+        Self((ClockImpl::estimate_current_cycles() / cycles_per_tick) as usize)
     }
 
     pub fn interrupt_after(diff: Self) {
@@ -82,8 +79,8 @@ impl Tick {
             ClockImpl::stop();
             return;
         }
-
-        ClockImpl::interrupt_at(ClockImpl::hz() / TICKS_PER_SECOND as u64 * n.0 as u64);
+        let cycles_per_tick = ClockImpl::hz() / TICKS_PER_SECOND as u64;
+        ClockImpl::interrupt_at(cycles_per_tick * n.0 as u64);
     }
 }
 
@@ -110,9 +107,11 @@ pub fn now() -> Duration {
 }
 
 pub fn from_clock_cycles(cycles: u64) -> Duration {
-    // Use u128 to avoid multiplication overflow when cycles is large
-    let now = (cycles as u128 * 1_000_000_000u128 / ClockImpl::hz() as u128) as u64;
-    Duration::from_nanos(now)
+    let hz = ClockImpl::hz();
+    let secs = cycles / hz;
+    let sub_cycles = cycles % hz;
+    let sub_nanos = (sub_cycles * 1_000_000_000 / hz) as u32;
+    Duration::new(secs, sub_nanos)
 }
 
 pub struct ScopeTimer<'a> {

--- a/kernel/src/time.rs
+++ b/kernel/src/time.rs
@@ -45,7 +45,7 @@ impl Tick {
             return Self::MAX;
         }
         let now = Self::now();
-        Self(Self::now().0 + n.0)
+        Self(now.0 + n.0)
     }
 
     pub fn add(&self, n: Self) -> Self {
@@ -64,8 +64,9 @@ impl Tick {
 
     pub fn now() -> Self {
         debug_assert_eq!(ClockImpl::hz() % TICKS_PER_SECOND as u64, 0);
+        // Use u128 to avoid multiplication overflow when cycles is large
         Self(
-            (ClockImpl::estimate_current_cycles() * TICKS_PER_SECOND as u64 / ClockImpl::hz())
+            (ClockImpl::estimate_current_cycles() as u128 * TICKS_PER_SECOND as u128 / ClockImpl::hz() as u128)
                 as usize,
         )
     }
@@ -81,7 +82,8 @@ impl Tick {
             ClockImpl::stop();
             return;
         }
-        ClockImpl::interrupt_at(ClockImpl::hz() * n.0 as u64 / TICKS_PER_SECOND as u64);
+        // Use u128 to avoid multiplication overflow when n is large
+        ClockImpl::interrupt_at((ClockImpl::hz() as u128 * n.0 as u128 / TICKS_PER_SECOND as u128) as u64);
     }
 }
 
@@ -108,7 +110,8 @@ pub fn now() -> Duration {
 }
 
 pub fn from_clock_cycles(cycles: u64) -> Duration {
-    let now = 1_000_000_000 * cycles / ClockImpl::hz();
+    // Use u128 to avoid multiplication overflow when cycles is large
+    let now = (cycles as u128 * 1_000_000_000u128 / ClockImpl::hz() as u128) as u64;
     Duration::from_nanos(now)
 }
 

--- a/kernel/src/time.rs
+++ b/kernel/src/time.rs
@@ -82,10 +82,8 @@ impl Tick {
             ClockImpl::stop();
             return;
         }
-        // Use u128 to avoid multiplication overflow when n is large
-        ClockImpl::interrupt_at(
-            (ClockImpl::hz() as u128 * n.0 as u128 / TICKS_PER_SECOND as u128) as u64,
-        );
+
+        ClockImpl::interrupt_at(ClockImpl::hz() / TICKS_PER_SECOND as u64 * n.0 as u64);
     }
 }
 

--- a/kernel/src/time/timer.rs
+++ b/kernel/src/time/timer.rs
@@ -380,7 +380,7 @@ mod tests {
             tm.mode = TimerMode::Repeat(r);
             tm.callback = callback;
             iou = add_soft_timer(&mut tm).unwrap();
-            scheduler::suspend_me_until::<()>(base_deadline.add(Tick(21)), None);
+            scheduler::suspend_me_until::<()>(base_deadline.add(Tick(30)), None);
             iou = remove_soft_timer(iou).unwrap();
         });
         assert_eq!(counter.load(Ordering::Relaxed), 3);

--- a/kernel/src/time/timer.rs
+++ b/kernel/src/time/timer.rs
@@ -380,7 +380,7 @@ mod tests {
             tm.mode = TimerMode::Repeat(r);
             tm.callback = callback;
             iou = add_soft_timer(&mut tm).unwrap();
-            scheduler::suspend_me_until::<()>(base_deadline.add(Tick(30)), None);
+            scheduler::suspend_me_until::<()>(base_deadline.add(Tick(21)), None);
             iou = remove_soft_timer(iou).unwrap();
         });
         assert_eq!(counter.load(Ordering::Relaxed), 3);


### PR DESCRIPTION
Fixes the multiplication overflow issue in the from_clock_cycles function in kernel/src/time.rs.
```
panicked at ../../kernel/kernel/src/time.rs:114:15:
attempt to multiply with overflow
Oops: attempt to multiply with overflow
```
This patch ensures safe arithmetic when converting clock cycles to time values.