### PR TITLE
Add early printk supports

### DIFF
--- a/hal/src/lib.rs
+++ b/hal/src/lib.rs
@@ -91,9 +91,7 @@ pub trait HasLineStatusReg {
     ///
     /// This method is typically used to ensure the bus is idle before starting
     /// a new transmission, preventing data corruption or transmission conflicts.
-    fn is_bus_busy(&self) -> bool {
-        false
-    }
+    fn is_bus_busy(&self) -> bool;
 }
 
 /// 8-bit data register operations trait

--- a/kernel/src/console.rs
+++ b/kernel/src/console.rs
@@ -32,6 +32,9 @@ macro_rules! kprintln {
     });
 }
 
+/// Provides a way to print messages before the console device is initialized.
+/// It directly writes to the UART registers, so it can be used in the early
+/// stage of the kernel initialization.
 #[macro_export]
 macro_rules! kearly_println {
     ($fmt:expr) => ({

--- a/kernel/src/console.rs
+++ b/kernel/src/console.rs
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::devices::console::{get_console, get_early_uart};
+use crate::{
+    devices::console::{get_console, get_early_uart},
+    support::DisableInterruptGuard,
+};
 use core::{fmt, str};
 
 #[macro_export]
@@ -54,8 +57,12 @@ impl fmt::Write for Console {
 pub struct EarlyConsole;
 impl fmt::Write for EarlyConsole {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        let mut uart = get_early_uart().lock();
-        let _ = uart.write_str(s);
+        use blueos_hal::Has8bitDataReg;
+        let _guard = DisableInterruptGuard::new();
+        let uart = crate::boards::get_device!(console_uart);
+        for byte in s.as_bytes() {
+            uart.write_data8(*byte);
+        }
         Ok(())
     }
 }

--- a/kernel/src/console.rs
+++ b/kernel/src/console.rs
@@ -12,10 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::{
-    devices::console::{get_console, get_early_uart},
-    support::DisableInterruptGuard,
-};
+use crate::{devices::console::get_console, support::DisableInterruptGuard};
 use core::{fmt, str};
 
 #[macro_export]

--- a/kernel/src/console.rs
+++ b/kernel/src/console.rs
@@ -57,10 +57,11 @@ impl fmt::Write for Console {
 pub struct EarlyConsole;
 impl fmt::Write for EarlyConsole {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        use blueos_hal::Has8bitDataReg;
+        use blueos_hal::{Has8bitDataReg, HasLineStatusReg};
         let _guard = DisableInterruptGuard::new();
         let uart = crate::boards::get_device!(console_uart);
         for byte in s.as_bytes() {
+            while uart.is_bus_busy() {}
             uart.write_data8(*byte);
         }
         Ok(())

--- a/kernel/src/devices/console.rs
+++ b/kernel/src/devices/console.rs
@@ -28,8 +28,3 @@ pub fn init_console(device: Arc<dyn Device>) -> Result<(), ErrorKind> {
 pub fn get_console() -> Arc<dyn Device> {
     CONSOLE.get().unwrap().clone()
 }
-
-#[allow(unconditional_recursion)]
-pub fn get_early_uart() -> &'static SpinLock<dyn UartOps> {
-    get_early_uart()
-}

--- a/kernel/src/devices/dumb.rs
+++ b/kernel/src/devices/dumb.rs
@@ -98,10 +98,6 @@ impl UartOps for DumbUart {
     fn clear_tx_interrupt(&mut self) {}
 }
 
-pub(crate) fn get_early_uart<'a>() -> &'a SpinLock<dyn UartOps> {
-    &DUMB_UART0
-}
-
 static DUMB_SERIAL0: Once<Arc<dyn Device>> = Once::new();
 
 pub(crate) fn get_serial0() -> &'static Arc<dyn Device> {

--- a/kernel/src/lib.rs
+++ b/kernel/src/lib.rs
@@ -297,6 +297,14 @@ mod tests {
         assert!(tick2.0 - tick.0 <= 11);
     }
 
+    // In esp32c3, we use usb-serial as the console output,
+    // which does not support on qemu yet, so we skip this test on esp32c3 for now.
+    // See https://github.com/espressif/esp-toolchain-docs/blob/main/qemu/README.md
+    #[cfg_attr(not(target_chip = "esp32c3"), test)]
+    fn test_early_printk() {
+        kearly_println!("Hello from early_printk!");
+    }
+
     #[test]
     fn test_local_irq() {
         assert!(arch::local_irq_enabled());


### PR DESCRIPTION
"Provides a minimal SYSLOG output facility that can be used during the very early boot phase or when the system is in a down state, before the full SYSLOG subsystem or scheduler becomes available. And sends the resulting characters directly to the low-level output device using corrsponding registers.  It is primarily intended for debugging or diagnostic messages in contexts where interrupts may be disabled and locking is not yet functional."

Inspired by https://github.com/apache/nuttx/blob/master/drivers/syslog/syslog_early.c