### PR TITLE
eliminate redundant contains lookup in port allocation

### DIFF
--- a/kernel/src/net/net_manager.rs
+++ b/kernel/src/net/net_manager.rs
@@ -263,7 +263,7 @@ where
                     .min()
                     .unwrap_or(DEFAULT_DELAY_TIME_IN_MILLIS);
 
-                // Warning!!! Need to yield or sleep for a while , or other threads may have no change to insert msg to NETSTACK_QUEUE
+                // Warning!!! Need to yield or sleep for a while , or other threads may have no chance to insert msg to NETSTACK_QUEUE
                 if sleep_time == 0 {
                     scheduler::suspend_me_for::<()>(Tick(1), None);
                 } else {

--- a/kernel/src/net/port_generator.rs
+++ b/kernel/src/net/port_generator.rs
@@ -105,8 +105,7 @@ impl PortGenerator {
                 })
                 .expect("Atomic port counter should never fail");
 
-            if !ports.contains(&(candidate, socket_type)) {
-                ports.insert((candidate, socket_type));
+            if ports.insert((candidate, socket_type)) {
                 return Ok(candidate);
             }
         }


### PR DESCRIPTION
To reduce memory overhead and potential lock contention, we should consider refactoring the port allocation logic. Instead of storing the (u16, SocketType) tuple in a single Mutex, we can decouple the protocols and manage TCP and UDP port states independently.