### PR TITLE
Add configurable logger filter level

### DIFF
--- a/kconfig/config/Kconfig
+++ b/kconfig/config/Kconfig
@@ -16,3 +16,34 @@ config UNITTEST_THREAD_NUM
     default 64
     help
         Set the number of thread used by unittest.
+
+choice
+    prompt "Default global logger filter level"
+    default LOG_LEVEL_INFO
+    help
+      Set Logger filter level
+    config LOG_LEVEL_OFF
+        bool "off"
+        help
+          Set logger filter level to off
+    config LOG_LEVEL_ERROR
+        bool "error"
+        help
+          Set logger filter level to error
+    config LOG_LEVEL_WARN
+        bool "warn"
+        help
+          Set logger filter level to warn
+    config LOG_LEVEL_INFO
+        bool "info"
+        help
+          Set logger filter level to info
+    config LOG_LEVEL_DEBUG
+        bool "debug"
+        help
+          Set logger filter level to debug
+    config LOG_LEVEL_TRACE
+        bool "trace"
+        help
+          Set logger filter level to trace
+endchoice

--- a/kernel/src/logger.rs
+++ b/kernel/src/logger.rs
@@ -19,25 +19,6 @@ static LOGGER_MUTEX: SpinLock<()> = SpinLock::new(());
 
 struct Logger;
 
-pub enum LogLevel {
-    Trace,
-    Debug,
-    Info,
-    Warn,
-    Error,
-}
-
-///set max log level
-pub fn set_max_level(level: LogLevel) {
-    match level {
-        LogLevel::Trace => log::set_max_level(LevelFilter::Trace),
-        LogLevel::Debug => log::set_max_level(LevelFilter::Debug),
-        LogLevel::Info => log::set_max_level(LevelFilter::Info),
-        LogLevel::Warn => log::set_max_level(LevelFilter::Warn),
-        LogLevel::Error => log::set_max_level(LevelFilter::Error),
-    }
-}
-
 /// log init
 pub fn logger_init() {
     static LOGGER: Logger = Logger {};

--- a/kernel/src/logger.rs
+++ b/kernel/src/logger.rs
@@ -19,13 +19,23 @@ static LOGGER_MUTEX: SpinLock<()> = SpinLock::new(());
 
 struct Logger;
 
+#[cfg(log_level_off)]
+const DEFAULT_LOG_LEVEL: LevelFilter = LevelFilter::Off;
+#[cfg(log_level_error)]
+const DEFAULT_LOG_LEVEL: LevelFilter = LevelFilter::Error;
+#[cfg(log_level_warn)]
+const DEFAULT_LOG_LEVEL: LevelFilter = LevelFilter::Warn;
+#[cfg(log_level_info)]
+const DEFAULT_LOG_LEVEL: LevelFilter = LevelFilter::Info;
+#[cfg(log_level_debug)]
+const DEFAULT_LOG_LEVEL: LevelFilter = LevelFilter::Debug;
+#[cfg(log_level_trace)]
+const DEFAULT_LOG_LEVEL: LevelFilter = LevelFilter::Trace;
+
 /// log init
 pub fn logger_init() {
     static LOGGER: Logger = Logger {};
-    #[cfg(debug)]
-    log::set_max_level(LevelFilter::Info);
-    #[cfg(release)]
-    log::set_max_level(LevelFilter::Warn);
+    log::set_max_level(DEFAULT_LOG_LEVEL);
     log::set_logger(&LOGGER).unwrap();
 }
 


### PR DESCRIPTION
## Summary
- Add a Kconfig choice for the default global logger filter level.
- Wire the generated Rust cfg flags into `logger_init()` so the default log level is selected from Kconfig.
- Remove the unused runtime `LogLevel` wrapper and `set_max_level()` helper.

## Impact
The default logger filter is now configurable per board/build through Kconfig. The current default remains `info`, preserving the existing debug build behavior while making release/debug differences explicit through configuration rather than hard-coded cfg branches.

## Validation
- `gn gen out/qemu_riscv64.release --args='board="qemu_riscv64" build_type="release"'`
- `ninja -C out/qemu_riscv64.release kernel/kconfig:generate_rustflags_file`
- Confirmed generated `.config` contains `CONFIG_LOG_LEVEL_INFO=y` and `rustflags.txt` contains `log_level_info`.
- `ninja -C out/qemu_riscv64.release check_all`
