### PR TITLE
Implement EL1 MMU linearmap

### DIFF
--- a/arch/arm/arm64/Kconfig
+++ b/arch/arm/arm64/Kconfig
@@ -3,4 +3,11 @@ menu "Aarch64 Configuration"
 config NUM_IRQS
     int
 
+config KERNEL_VIRT_START
+    hex "Kernel virtual address start"
+    default 0xFFFFFF8000000000 if SOC_VIRT_AARCH64
+    default 0x0
+    help
+      Base virtual address used by the kernel linear mapping on AArch64.
+
 endmenu

--- a/kernel/src/arch/aarch64/mmu.rs
+++ b/kernel/src/arch/aarch64/mmu.rs
@@ -217,11 +217,27 @@ impl PageTableManager {
     }
 }
 
+// Indicate whether the page table initialization is done.
+static PAGETABLE_INIT_DONE: AtomicBool = AtomicBool::new(false);
+static LINEARMAP_INIT_DONE: AtomicBool = AtomicBool::new(false);
+
 pub fn enable_el1_mmu() {
     // Only allow CPU0 to initialize the page table, other cores wait
     let cpu_id = crate::arch::current_cpu_id();
     if cpu_id == 0 {
         PageTableManager::init();
+        PAGETABLE_INIT_DONE.store(true, Ordering::Release);
+        // Wake up all cores waiting on wfe
+        unsafe {
+            core::arch::asm!("sev", options(nostack, nomem));
+        }
+    } else {
+        // Wait for CPU0 to finish page table initialization.
+        while !PAGETABLE_INIT_DONE.load(Ordering::Acquire) {
+            unsafe {
+                core::arch::asm!("wfe", options(nostack, nomem));
+            }
+        }
     }
     // Set physical table base addr.
     unsafe {
@@ -269,6 +285,18 @@ pub fn el1_add_linearmap() {
     let cpu_id = crate::arch::current_cpu_id();
     if cpu_id == 0 {
         PageTableManager::init_linearmap();
+        LINEARMAP_INIT_DONE.store(true, Ordering::Release);
+        // Wake up all cores waiting on wfe
+        unsafe {
+            core::arch::asm!("sev", options(nostack, nomem));
+        }
+    } else {
+        // Wait for CPU0 to finish linearmap table initialization.
+        while !LINEARMAP_INIT_DONE.load(Ordering::Acquire) {
+            unsafe {
+                core::arch::asm!("wfe", options(nostack, nomem));
+            }
+        }
     }
 
     TTBR1_EL1.set(core::ptr::addr_of!(LINEARMAP_MANAGER) as u64);

--- a/kernel/src/arch/aarch64/mmu.rs
+++ b/kernel/src/arch/aarch64/mmu.rs
@@ -15,10 +15,33 @@
 use crate::arch::aarch64::{
     asm,
     asm::DsbOptions,
-    registers::{mair_el1::*, sctlr_el1::*, tcr_el1::*, ttbr0_el1::TTBR0_EL1},
+    registers::{
+        mair_el1::*, sctlr_el1::*, tcr_el1::*, ttbr0_el1::TTBR0_EL1, ttbr1_el1::TTBR1_EL1,
+    },
 };
 use core::sync::atomic::{AtomicBool, Ordering};
 use tock_registers::{interfaces::*, register_bitfields, registers::InMemoryRegister};
+
+const L1_BLOCK_SIZE: u64 = 1 << 30;
+const EL1_LINEARMAP_BLOCK_COUNT: usize = 4;
+const KERNEL_VA_BITS: u64 = 39;
+const KERNEL_TCR_TSZ: u64 = u64::BITS as u64 - KERNEL_VA_BITS;
+#[cfg(target_board = "qemu_virt64_aarch64")]
+pub(crate) const KERNEL_VIRT_START: u64 = u64::MAX << KERNEL_VA_BITS;
+#[cfg(not(target_board = "qemu_virt64_aarch64"))]
+pub(crate) const KERNEL_VIRT_START: u64 = 0;
+
+pub const fn kernel_virt_to_phys(addr: usize) -> usize {
+    if addr >= KERNEL_VIRT_START as usize {
+        addr - KERNEL_VIRT_START as usize
+    } else {
+        addr
+    }
+}
+
+pub const fn kernel_phys_to_virt(addr: u64) -> u64 {
+    KERNEL_VIRT_START + addr
+}
 
 #[repr(u64)]
 #[derive(Debug, Clone, Copy)]
@@ -157,6 +180,10 @@ impl PageEntry {
 #[link_section = ".data"]
 static mut TABLE_MANAGER: PageTableManager = PageTableManager::new();
 
+#[used]
+#[link_section = ".data"]
+static mut LINEARMAP_MANAGER: PageTableManager = PageTableManager::new();
+
 #[repr(C, align(4096))]
 pub struct PageTableManager([PageEntry; 512]);
 
@@ -176,28 +203,25 @@ impl PageTableManager {
             let _ = table.0[index].set(base, MemAttributes::Normal);
         }
     }
+
+    fn init_linearmap() {
+        let table = unsafe { &mut LINEARMAP_MANAGER };
+        for &base in crate::boards::MMU_L1_DEVICE_BASES {
+            let index = (base >> 30) as usize;
+            let _ = table.0[index].set(base, MemAttributes::Device);
+        }
+        for &base in crate::boards::MMU_L1_NORMAL_BASES {
+            let index = (base >> 30) as usize;
+            let _ = table.0[index].set(base, MemAttributes::Normal);
+        }
+    }
 }
 
-// Indicate whether the page table initialization is done.
-static PAGETABLE_INIT_DONE: AtomicBool = AtomicBool::new(false);
-
-pub fn enable_mmu() {
+pub fn enable_el1_mmu() {
     // Only allow CPU0 to initialize the page table, other cores wait
     let cpu_id = crate::arch::current_cpu_id();
     if cpu_id == 0 {
         PageTableManager::init();
-        PAGETABLE_INIT_DONE.store(true, Ordering::Release);
-        // Wake up all cores waiting on wfe
-        unsafe {
-            core::arch::asm!("sev", options(nostack, nomem));
-        }
-    } else {
-        // Wait for CPU0 to finish page table initialization.
-        while !PAGETABLE_INIT_DONE.load(Ordering::Acquire) {
-            unsafe {
-                core::arch::asm!("wfe", options(nostack, nomem));
-            }
-        }
     }
     // Set physical table base addr.
     unsafe {
@@ -225,7 +249,7 @@ pub fn enable_mmu() {
             + TCR_EL1::IRGN0::WriteBack_ReadAlloc_WriteAlloc_Cacheable
             + TCR_EL1::EPD1::DisableTTBR1Walks
             + TCR_EL1::EPD0::EnableTTBR0Walks
-            + TCR_EL1::T0SZ.val(25),
+            + TCR_EL1::T0SZ.val(KERNEL_TCR_TSZ),
     );
     // Clear tlb.
     asm::tlbi_all();
@@ -238,5 +262,27 @@ pub fn enable_mmu() {
             + SCTLR_EL1::I::Cacheable
             + SCTLR_EL1::SA::Enable,
     );
+    asm::isb_sy();
+}
+
+pub fn el1_add_linearmap() {
+    let cpu_id = crate::arch::current_cpu_id();
+    if cpu_id == 0 {
+        PageTableManager::init_linearmap();
+    }
+
+    TTBR1_EL1.set(core::ptr::addr_of!(LINEARMAP_MANAGER) as u64);
+
+    TCR_EL1.modify(
+        TCR_EL1::TG1::KiB_4
+            + TCR_EL1::SH1::InnerShareable
+            + TCR_EL1::ORGN1::WriteBack_ReadAlloc_WriteAlloc_Cacheable
+            + TCR_EL1::IRGN1::WriteBack_ReadAlloc_WriteAlloc_Cacheable
+            + TCR_EL1::EPD1::EnableTTBR1Walks
+            + TCR_EL1::T1SZ.val(KERNEL_TCR_TSZ),
+    );
+
+    asm::tlbi_all();
+    asm::dsb(DsbOptions::Sys);
     asm::isb_sy();
 }

--- a/kernel/src/arch/aarch64/mmu.rs
+++ b/kernel/src/arch/aarch64/mmu.rs
@@ -54,10 +54,7 @@ const L1_BLOCK_SIZE: u64 = 1 << 30;
 const EL1_LINEARMAP_BLOCK_COUNT: usize = 4;
 const KERNEL_VA_BITS: u64 = 39;
 const KERNEL_TCR_TSZ: u64 = u64::BITS as u64 - KERNEL_VA_BITS;
-#[cfg(target_board = "qemu_virt64_aarch64")]
-pub(crate) const KERNEL_VIRT_START: u64 = u64::MAX << KERNEL_VA_BITS;
-#[cfg(not(target_board = "qemu_virt64_aarch64"))]
-pub(crate) const KERNEL_VIRT_START: u64 = 0;
+pub(crate) const KERNEL_VIRT_START: u64 = blueos_kconfig::CONFIG_KERNEL_VIRT_START as u64;
 
 pub const fn kernel_virt_to_phys(addr: usize) -> usize {
     if addr >= KERNEL_VIRT_START as usize {

--- a/kernel/src/arch/aarch64/mmu.rs
+++ b/kernel/src/arch/aarch64/mmu.rs
@@ -246,7 +246,7 @@ impl PageTableManager {
 static PAGETABLE_INIT_DONE: AtomicBool = AtomicBool::new(false);
 static LINEARMAP_INIT_DONE: AtomicBool = AtomicBool::new(false);
 
-pub fn enable_el1_mmu() {
+pub fn init_el1_enable_mmu() {
     // Only allow CPU0 to initialize the page table, other cores wait
     let cpu_id = crate::arch::current_cpu_id();
     if cpu_id == 0 {
@@ -306,7 +306,7 @@ pub fn enable_el1_mmu() {
     asm::isb_sy();
 }
 
-pub fn el1_add_linearmap() {
+pub fn init_el1_boot_linearmap() {
     let cpu_id = crate::arch::current_cpu_id();
     if cpu_id == 0 {
         PageTableManager::init_linearmap();

--- a/kernel/src/arch/aarch64/mmu.rs
+++ b/kernel/src/arch/aarch64/mmu.rs
@@ -12,6 +12,34 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ============================================================================
+// Linear Mapping Layout (AArch64 EL1)
+// ============================================================================
+//
+// KERNEL_VA_BITS = 39   →  512 GB virtual address space
+// LINEAR_OFFSET  = 0xFFFF_FF80_0000_0000  (u64::MAX << 39)
+//
+//   Virtual Address Space (TTBR1, 39-bit)
+//   ┌─────────────────────────────────────────────────────────┐ 0xFFFF_FFFF_FFFF_FFFF
+//   │                                                         │
+//   │  ┌─────────────────────────────────────────────────────┐│ 0xFFFF_FFFF_0000_0000 + 4 GB
+//   │  │  Linear-mapped DRAM (4 × 1 GB L1 blocks)           ││
+//   │  │  PA 0x0000_0000_0000 → VA 0xFFFF_FF80_0000_0000    ││
+//   │  │  PA 0x0000_4000_0000 → VA 0xFFFF_FF80_4000_0000    ││
+//   │  │  PA 0x0000_8000_0000 → VA 0xFFFF_FF80_8000_0000    ││
+//   │  │  PA 0x0000_C000_0000 → VA 0xFFFF_FF80_C000_0000    ││
+//   │  └─────────────────────────────────────────────────────┘│ 0xFFFF_FF80_0000_0000 ← KERNEL_VIRT_START
+//   │                                                         │
+//   │  (unmapped)                                             │
+//   │                                                         │
+//   └─────────────────────────────────────────────────────────┘ 0xFFFF_FF80_0000_0000
+//
+//   Translation:
+//     VA = PA + LINEAR_OFFSET   (kernel_phys_to_virt)
+//     PA = VA - LINEAR_OFFSET   (kernel_virt_to_phys)
+//
+// ============================================================================
+
 use crate::arch::aarch64::{
     asm,
     asm::DsbOptions,

--- a/kernel/src/arch/aarch64/mod.rs
+++ b/kernel/src/arch/aarch64/mod.rs
@@ -105,11 +105,8 @@ macro_rules! enter_el1 {
         mov x19, x1
         sub x2, x1, #0x1000
         msr sp_el1, x2
-        // // Enable to switch into EL2.
-        // bl {virt_init}
-        // Enable AArch64 in EL1.
-        mov x3, #(1 << 31)
-        msr hcr_el2, x3
+        // Enable to switch into EL2.
+        bl {virt_init}
         // Set EL1 sp and mask daif in EL2.
         mov x0, #0x3C5
         msr spsr_el2, x0

--- a/kernel/src/arch/aarch64/mod.rs
+++ b/kernel/src/arch/aarch64/mod.rs
@@ -51,6 +51,28 @@ macro_rules! enable_interrupt {
     };
 }
 
+#[cfg(target_board = "qemu_virt64_aarch64")]
+macro_rules! clear_ttbr0_el1 {
+    () => {
+        "
+                // clear ttbr0_el1
+                msr ttbr0_el1, xzr
+                dsb ish
+                isb
+                tlbi vmalle1
+                dsb ish
+                isb
+        "
+    };
+}
+
+#[cfg(not(target_board = "qemu_virt64_aarch64"))]
+macro_rules! clear_ttbr0_el1 {
+    () => {
+        ""
+    };
+}
+
 // Temporary stack used during early boot (before MMU is enabled).
 #[repr(C, align(16))]
 pub struct TempBootStack([u8; 4096]);
@@ -475,22 +497,20 @@ pub(crate) extern "C" fn jump_to_high_va() -> ! {
 pub(crate) extern "C" fn init() -> ! {
     unsafe {
         core::arch::naked_asm!(
-            "
+            concat!(
+                "
                 // set sp
                 mrs x8, mpidr_el1
                 and x8, x8, #0Xff
                 lsl x8, x8, #14
                 sub sp, x1, x8 
-                // clear ttbr0_el1
-                msr ttbr0_el1, xzr
-                dsb ish
-                isb
-                tlbi vmalle1
-                dsb ish
-                isb
+                ",
+                clear_ttbr0_el1!(),
+                "
                 // branch to a far address
                 br x2
-            "
+                "
+            )
         )
     }
 }

--- a/kernel/src/arch/aarch64/mod.rs
+++ b/kernel/src/arch/aarch64/mod.rs
@@ -496,22 +496,20 @@ pub(crate) extern "C" fn jump_to_high_va() -> ! {
 #[naked]
 pub(crate) extern "C" fn init() -> ! {
     unsafe {
-        core::arch::naked_asm!(
-            concat!(
-                "
+        core::arch::naked_asm!(concat!(
+            "
                 // set sp
                 mrs x8, mpidr_el1
                 and x8, x8, #0Xff
                 lsl x8, x8, #14
                 sub sp, x1, x8 
                 ",
-                clear_ttbr0_el1!(),
-                "
+            clear_ttbr0_el1!(),
+            "
                 // branch to a far address
                 br x2
                 "
-            )
-        )
+        ))
     }
 }
 

--- a/kernel/src/arch/aarch64/mod.rs
+++ b/kernel/src/arch/aarch64/mod.rs
@@ -73,6 +73,8 @@ macro_rules! enter_el1 {
         // Calculate per-core stack offset
         // We reserve the top 4KB of each core's 16KB chunk for EL2.
         ldr x1, ={stack_end}
+        ldr x12, ={kernel_virt_start}
+        sub x1, x1, x12
         mrs x9, mpidr_el1
         and x9, x9, #0xff
         lsl x9, x9, #14
@@ -81,20 +83,28 @@ macro_rules! enter_el1 {
         mov x19, x1
         sub x2, x1, #0x1000
         msr sp_el1, x2
-        // Enable to switch into EL2.
-        bl {virt_init}
+        // // Enable to switch into EL2.
+        // bl {virt_init}
+        // Enable AArch64 in EL1.
+        mov x3, #(1 << 31)
+        msr hcr_el2, x3
         // Set EL1 sp and mask daif in EL2.
         mov x0, #0x3C5
         msr spsr_el2, x0
         // Enable EL1 MMU while still in EL2.
         ldr x4, ={tmp_stack}
+        ldr x12, ={kernel_virt_start}
+        sub x4, x4, x12
         add x4, x4, #0x1000
         mov sp, x4
-        bl {enable_mmu}
+        bl {enable_el1_mmu}
+        bl {el1_add_linearmap}
         mov sp, x19
         // Set EL1 entry and enter.
         ldr x0, ={stack_start}
+        ldr x1, ={stack_end}
         ldr x2, ={cont}
+        // adr is PC-relative
         adr x3, {entry}
         msr elr_el2, x3
         eret
@@ -107,9 +117,11 @@ macro_rules! arch_bootstrap {
     ($stack_start:path, $stack_end:path, $cont: path) => {
         core::arch::naked_asm!(
             $crate::enter_el1!(),
-            entry = sym $crate::arch::aarch64::init,
+            entry = sym $crate::arch::aarch64::jump_to_high_va,
             virt_init = sym $crate::arch::aarch64::virt::virt_init,
-            enable_mmu = sym $crate::arch::aarch64::mmu::enable_mmu,
+            enable_el1_mmu = sym $crate::arch::aarch64::mmu::enable_el1_mmu,
+            el1_add_linearmap = sym $crate::arch::aarch64::mmu::el1_add_linearmap,
+            kernel_virt_start = const $crate::arch::aarch64::mmu::KERNEL_VIRT_START,
             tmp_stack = sym $crate::arch::aarch64::TEMP_BOOT_STACK,
             stack_start = sym $stack_start,
             stack_end = sym $stack_end,
@@ -447,14 +459,36 @@ pub(crate) extern "C" fn switch_context_with_hook(hook: *mut ContextSwitchHookHo
 }
 
 #[naked]
+pub(crate) extern "C" fn jump_to_high_va() -> ! {
+    unsafe {
+        core::arch::naked_asm!(
+            "
+                ldr x16, ={init}
+                br x16
+            ",
+            init = sym crate::arch::aarch64::init,
+        )
+    }
+}
+
+#[naked]
 pub(crate) extern "C" fn init() -> ! {
     unsafe {
         core::arch::naked_asm!(
             "
+                // set sp
                 mrs x8, mpidr_el1
                 and x8, x8, #0Xff
                 lsl x8, x8, #14
                 sub sp, x1, x8 
+                // clear ttbr0_el1
+                msr ttbr0_el1, xzr
+                dsb ish
+                isb
+                tlbi vmalle1
+                dsb ish
+                isb
+                // branch to a far address
                 br x2
             "
         )
@@ -544,8 +578,9 @@ pub extern "C" fn pend_switch_context() {}
 
 pub fn secondary_cpu_setup(psci_base: u32) {
     atomic::fence(Ordering::SeqCst);
+    let secondary_entry = mmu::kernel_virt_to_phys(crate::boot::_start as usize);
     for i in 1..blueos_kconfig::CONFIG_NUM_CORES {
-        psci::cpu_on(psci_base, i as usize, crate::boot::_start as usize, 0);
+        psci::cpu_on(psci_base, i as usize, secondary_entry, 0);
     }
 }
 

--- a/kernel/src/arch/aarch64/mod.rs
+++ b/kernel/src/arch/aarch64/mod.rs
@@ -120,8 +120,8 @@ macro_rules! enter_el1 {
         sub x4, x4, x12
         add x4, x4, #0x1000
         mov sp, x4
-        bl {enable_el1_mmu}
-        bl {el1_add_linearmap}
+        bl {init_el1_enable_mmu}
+        bl {init_el1_boot_linearmap}
         mov sp, x19
         // Set EL1 entry and enter.
         ldr x0, ={stack_start}
@@ -142,8 +142,8 @@ macro_rules! arch_bootstrap {
             $crate::enter_el1!(),
             entry = sym $crate::arch::aarch64::jump_to_high_va,
             virt_init = sym $crate::arch::aarch64::virt::virt_init,
-            enable_el1_mmu = sym $crate::arch::aarch64::mmu::enable_el1_mmu,
-            el1_add_linearmap = sym $crate::arch::aarch64::mmu::el1_add_linearmap,
+            init_el1_enable_mmu = sym $crate::arch::aarch64::mmu::init_el1_enable_mmu,
+            init_el1_boot_linearmap = sym $crate::arch::aarch64::mmu::init_el1_boot_linearmap,
             kernel_virt_start = const $crate::arch::aarch64::mmu::KERNEL_VIRT_START,
             tmp_stack = sym $crate::arch::aarch64::TEMP_BOOT_STACK,
             stack_start = sym $stack_start,

--- a/kernel/src/arch/aarch64/mod.rs
+++ b/kernel/src/arch/aarch64/mod.rs
@@ -51,6 +51,8 @@ macro_rules! enable_interrupt {
     };
 }
 
+// FIXME: After adapting to other AArch64 platforms, the
+// hardcoded board-specific configuration should be removed.
 #[cfg(target_board = "qemu_virt64_aarch64")]
 macro_rules! clear_ttbr0_el1 {
     () => {
@@ -66,6 +68,8 @@ macro_rules! clear_ttbr0_el1 {
     };
 }
 
+// FIXME: After adapting to other AArch64 platforms, the
+// hardcoded board-specific configuration should be removed.
 #[cfg(not(target_board = "qemu_virt64_aarch64"))]
 macro_rules! clear_ttbr0_el1 {
     () => {

--- a/kernel/src/boards/qemu_virt64_aarch64/config.rs
+++ b/kernel/src/boards/qemu_virt64_aarch64/config.rs
@@ -12,16 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use crate::arch::irq::IrqNumber;
+use crate::arch::{aarch64::mmu, irq::IrqNumber};
 
-pub const UART0_BASE_S: u64 = 0x59303000;
+pub const UART0_BASE_S: u64 = mmu::kernel_phys_to_virt(0x59303000);
 pub const APBP_CLOCK: u32 = 0x16e3600;
-pub const PL011_UART0_BASE: u64 = 0x900_0000;
+pub const PL011_UART0_BASE: u64 = mmu::kernel_phys_to_virt(0x900_0000);
 pub const PL011_UART0_IRQNUM: IrqNumber = IrqNumber::new(33);
 pub const GENERIC_TIMER_IRQNUM: IrqNumber = IrqNumber::new(30);
 pub const HEAP_SIZE: u64 = 16 * 1024 * 1024;
 pub const PSCI_BASE: u32 = 0x84000000;
-pub const GICD: usize = 0x8000000;
-pub const GICR: usize = 0x80a0000;
+pub const GICD: usize = mmu::kernel_phys_to_virt(0x8000000) as usize;
+pub const GICR: usize = mmu::kernel_phys_to_virt(0x80a0000) as usize;
 pub const MMU_L1_NORMAL_BASES: &[u64] = &[0x4008_0000];
 pub const MMU_L1_DEVICE_BASES: &[u64] = &[0x0];

--- a/kernel/src/boards/qemu_virt64_aarch64/init.rs
+++ b/kernel/src/boards/qemu_virt64_aarch64/init.rs
@@ -18,6 +18,7 @@ use crate::{
     arch::{
         irq,
         irq::{IrqTrigger, Priority},
+        mmu,
         registers::cntfrq_el0::CNTFRQ_EL0,
     },
     error::Error,
@@ -89,7 +90,7 @@ crate::define_peripheral! {
      )),
 }
 
-pub const DRAM_BASE: u64 = 0x4000_0000;
+pub const DRAM_BASE: u64 = mmu::kernel_phys_to_virt(0x4000_0000);
 
 crate::define_pin_states!(None);
 

--- a/kernel/src/boards/qemu_virt64_aarch64/link.x
+++ b/kernel/src/boards/qemu_virt64_aarch64/link.x
@@ -2,10 +2,11 @@ OUTPUT_FORMAT("elf64-littleaarch64", "elf64-littleaarch64", "elf64-littleaarch64
 OUTPUT_ARCH(aarch64)
 
 STACK_SIZE = 128 * 1024;
+KERNEL_OFFSET = 0xFFFFFF8000000000;
 
 MEMORY
 {
-	DRAM : ORIGIN = 0x40280000, LENGTH = 32M
+       DRAM : ORIGIN = 0x40280000 + KERNEL_OFFSET, LENGTH = 32M
 }
 
 PHDRS
@@ -20,7 +21,7 @@ PHDRS
 ENTRY(_start)
 SECTIONS
 {
-    .text :
+    .text : AT(ADDR(.text) - KERNEL_OFFSET)
     {
         __text_start = .;
         _start = .;
@@ -33,28 +34,28 @@ SECTIONS
         __text_end = .;
     } > DRAM :text
 
-    .rodata : ALIGN(4096)
+    .rodata : AT(ADDR(.rodata) - KERNEL_OFFSET) ALIGN(4096)
     {
         __rodata_start = .;
         *(.rodata*)
         __rodata_end = .;
     } > DRAM :rodata
 
-    .data : ALIGN(4096)
+    .data : AT(ADDR(.data) - KERNEL_OFFSET) ALIGN(4096)
     {
         __data_start = .;
         *(.data*)
         __data_end = .;
     } > DRAM :data
 
-    .bss : ALIGN(4096)
+    .bss : AT(ADDR(.bss) - KERNEL_OFFSET) ALIGN(4096)
     {
         __bss_start = .;
         *(.bss*)
         __bss_end = .;
     } > DRAM :data
 
-    .init_array : {
+    .init_array : AT(ADDR(.init_array) - KERNEL_OFFSET) {
       . = ALIGN(16);
       PROVIDE_HIDDEN (__init_array_start = .);
       KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*)))
@@ -62,7 +63,7 @@ SECTIONS
       PROVIDE_HIDDEN (__init_array_end = .);
     } > DRAM :data
 
-    .bk_app_array : {
+    .bk_app_array : AT(ADDR(.bk_app_array) - KERNEL_OFFSET) {
       . = ALIGN(16);
       PROVIDE_HIDDEN (__bk_app_array_start = .);
       KEEP (*(SORT_BY_INIT_PRIORITY(.bk_app_array.*)))
@@ -70,7 +71,7 @@ SECTIONS
       PROVIDE_HIDDEN (__bk_app_array_end = .);
     } > DRAM :data
 
-    .stack : ALIGN(4096)
+    .stack : AT(ADDR(.stack) - KERNEL_OFFSET) ALIGN(4096)
     {
         __sys_stack_start = .;
         . += STACK_SIZE;

--- a/kernel/src/devices/virtio.rs
+++ b/kernel/src/devices/virtio.rs
@@ -47,8 +47,10 @@ fn find_virtio_mmio_devices(fdt: &Fdt) {
                             size_of::<VirtIOHeader>()
                         );
                     } else {
-                        let header =
-                            NonNull::new(region.starting_address as *mut VirtIOHeader).unwrap();
+                        let header = NonNull::new(
+                            phys_to_virt(region.starting_address as usize) as *mut VirtIOHeader
+                        )
+                        .unwrap();
                         // SAFETY: device tree is correct, VirtIO MMIO devices are mapped.
                         match unsafe { MmioTransport::new(header, region_size) } {
                             Err(MmioError::InvalidDeviceID(
@@ -119,7 +121,7 @@ unsafe impl Hal for VirtioHal {
     }
 
     unsafe fn mmio_phys_to_virt(paddr: PhysAddr, _size: usize) -> NonNull<u8> {
-        NonNull::new(paddr as _).unwrap()
+        NonNull::new(phys_to_virt(paddr) as _).unwrap()
     }
 
     unsafe fn share(buffer: NonNull<[u8]>, _direction: BufferDirection) -> PhysAddr {
@@ -135,5 +137,25 @@ unsafe impl Hal for VirtioHal {
 }
 
 fn virt_to_phys(vaddr: usize) -> PhysAddr {
-    vaddr
+    #[cfg(target_arch = "aarch64")]
+    {
+        crate::arch::aarch64::mmu::kernel_virt_to_phys(vaddr)
+    }
+
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        vaddr
+    }
+}
+
+fn phys_to_virt(paddr: PhysAddr) -> usize {
+    #[cfg(target_arch = "aarch64")]
+    {
+        crate::arch::aarch64::mmu::kernel_phys_to_virt(paddr as u64) as usize
+    }
+
+    #[cfg(not(target_arch = "aarch64"))]
+    {
+        paddr
+    }
 }


### PR DESCRIPTION

## Summary

This PR implements an EL1 MMU linear mapping for the AArch64 kernel, using `TTBR1_EL1` to map physical memory into the kernel’s high virtual address space. It also updates the AArch64 boot path so the kernel switches from the early identity-mapped execution environment into the high virtual address space after `eret`.

The default kernel virtual base for `qemu_virt64_aarch64` is now configured as:

```text
0xFFFFFF8000000000
```

## Main Changes

- Add `CONFIG_KERNEL_VIRT_START` for AArch64.
- Add AArch64 EL1 linear map support in `mmu.rs`.
- Introduce helpers:
  - `kernel_phys_to_virt()`
  - `kernel_virt_to_phys()`
- Split MMU initialization into:
  - `init_el1_enable_mmu()`
  - `init_el1_boot_linearmap()`
- Configure `TTBR1_EL1` for the kernel linear map.
- Add a 39-bit kernel virtual address layout using `T1SZ/T0SZ`.
- Update the AArch64 boot flow to jump to `jump_to_high_va()` after `eret`.
- Adjust stack and boot addresses when transitioning between physical and virtual addresses.
- Update the `qemu_virt64_aarch64` linker script to link the kernel at the high virtual address while loading it at the physical address.
- Convert board MMIO/DRAM constants to kernel virtual addresses.
- Update VirtIO address translation so MMIO and shared buffers correctly translate between physical and virtual addresses.
- Use physical entry addresses when booting secondary CPUs through PSCI.

## Memory Layout

The kernel now uses a high virtual linear map for AArch64 EL1:

```text
VA = PA + KERNEL_VIRT_START
PA = VA - KERNEL_VIRT_START
```

## Files Changed

- `arch/arm/arm64/Kconfig`
  - Adds `CONFIG_KERNEL_VIRT_START`.

- `kernel/src/arch/aarch64/mmu.rs`
  - Adds linear map page table setup.
  - Adds physical/virtual conversion helpers.
  - Enables `TTBR1_EL1` walks for the kernel linear map.
  - Documents the AArch64 linear mapping layout.

- `kernel/src/arch/aarch64/mod.rs`
  - Updates the EL2-to-EL1 boot path.
  - Adds `jump_to_high_va()`.
  - Handles board-specific `TTBR0_EL1` clearing for `qemu_virt64_aarch64`.
  - Converts secondary CPU boot entry to a physical address.

- `kernel/src/boards/qemu_virt64_aarch64/config.rs`
  - Converts MMIO constants to kernel virtual addresses.

- `kernel/src/boards/qemu_virt64_aarch64/init.rs`
  - Converts `DRAM_BASE` to a kernel virtual address.

- `kernel/src/boards/qemu_virt64_aarch64/link.x`
  - Links the kernel at the high virtual address.
  - Uses `AT(...)` to preserve the physical load address.

- `kernel/src/devices/virtio.rs`
  - Adds AArch64-aware VirtIO physical/virtual address translation.

## Notes

Some AArch64 boot behavior is currently specific to `qemu_virt64_aarch64`, especially the `TTBR0_EL1` clearing logic. FIXME comments were added to mark this as board-specific code that should be generalized when additional AArch64 platforms are adapted.
