### PR TITLE
[codex] Respect preempt disable before PendSV

### DIFF
--- a/kernel/src/arch/arm/irq.rs
+++ b/kernel/src/arch/arm/irq.rs
@@ -156,15 +156,9 @@ extern "C" fn _generic_isr_handler() {
 
     #[cfg(round_robin)]
     {
-        use core::intrinsics::likely;
-
-        use crate::scheduler::is_schedule_ready;
-
-        if likely(is_schedule_ready()) {
-            // If the scheduler is preemptive, trigger PendSV to perform
-            // a context switch after handling the current interrupt.
-            cortex_m::peripheral::SCB::set_pendsv();
-        }
+        // If the scheduler is preemptive, trigger PendSV to perform
+        // a context switch after handling the current interrupt.
+        crate::scheduler::yield_me_now_or_later();
     }
 }
 


### PR DESCRIPTION
## Summary

- Route generic ARM IRQ reschedule requests through `scheduler::yield_me_now_or_later()`.
- Avoid delivering PendSV while the current thread is inside a `disable_preempt()` window.

## Root Cause

Generic IRQ handling on Cortex-M directly pended PendSV after an interrupt when round-robin scheduling was enabled. That bypassed the scheduler's `preempt_count` check, so an interrupt could request and deliver a context switch while the current thread still had preemption disabled.

In issue #404 this showed up as `test_os_mutex_new` panicking at `scheduler/mod.rs:260`, where PendSV entered `relinquish_me_and_return_next_sp()` with `preempt_count == 1`.

Fixes #404.

## Testing

- `ninja -C out/qemu_mps2_an385.debug run_cmsis_unittest`
- Reproduced the old behavior by isolating `test_os_mutex_new` with `test_only` and `repeat = 1000`; the old direct-PendSV path failed around iteration 190, while the new path completed 1000 iterations.
