### PR TITLE
fix(linker): place GOT sections within .data to ensure proper init

### DIFF
--- a/arch/arm/cortex_m/link.x
+++ b/arch/arm/cortex_m/link.x
@@ -176,6 +176,21 @@ SECTIONS
     __stop___llvm_prf_data = .;
 
     KEEP(*(.jcr*))
+
+    /*
+     * Keep GOT sections inside the copied data range. The linker may emit
+     * PC-relative loads through .got for optimized Rust code even in this
+     * bare-metal image; if .got becomes an orphan section after __data_end,
+     * the startup copy table leaves it zeroed in RAM and indirect calls can
+     * branch through a null entry.
+     */
+    . = ALIGN(4);
+    *(.got)
+    *(.got.*)
+    *(.igot.*)
+    *(.got.plt)
+    *(.igot.plt)
+
     . = ALIGN(4);
     __data_end = .;
 


### PR DESCRIPTION
## Summary

- Include `.got`, `.got.*`, `.igot.*`, `.got.plt`, and `.igot.plt` sections inside the `.data` output section in the Cortex-M linker script
- Without this, `.got` becomes an orphan section placed after `__data_end`, so the startup copy table does not copy it from flash to RAM, leaving its entries zeroed at runtime
- This affects bare-metal Rust code where the compiler may emit PC-relative loads referencing .got entries