### PR TITLE
feat: add DTS include support for build-time device tree generation

### DIFF
--- a/kernel/BUILD.gn
+++ b/kernel/BUILD.gn
@@ -91,6 +91,10 @@ build_rust("kernel_unittest") {
   cfgs = _kernel_default_cfgs
   deps = _shared_deps
   deps += [ "//external/vendor/semihosting-0.1.20:semihosting" ]
+  if (defined(dts_file)) {
+    deps += [ "//build/boards/${board}:dts_gen_${board}" ]
+    rustenv += [ "DTS_OUT_DIR=${dts_out_dir}" ]
+  }
   configs += [
     "//kernel/kconfig:kconfigs",
     "//build/boards/${board}:kernel_config",
@@ -159,6 +163,10 @@ build_rust("blueos") {
   rustenv = [ "TARGET_BOARD=${board}" ]
   cfgs = _kernel_default_cfgs
   deps = _shared_deps
+  if (defined(dts_file)) {
+    deps += [ "//build/boards/${board}:dts_gen_${board}" ]
+    rustenv += [ "DTS_OUT_DIR=${dts_out_dir}" ]
+  }
   public_deps = board_deps
   public_deps += [ "//kernel/kconfig:generate_rustflags_file" ]
   public_configs += [

--- a/kernel/src/boards/qemu_riscv64/mod.rs
+++ b/kernel/src/boards/qemu_riscv64/mod.rs
@@ -20,6 +20,10 @@
 // SPDX-License-Identifier: MIT
 
 mod config;
+/// Device tree generated modules (build-time).
+pub mod dts {
+    include!(concat!(env!("DTS_OUT_DIR"), "/mod.rs"));
+}
 use crate::{
     arch,
     arch::riscv::{local_irq_enabled, trap_entry, Context},


### PR DESCRIPTION
## Summary

Integrate the DTS build framework from the `build` repository into the kernel.

- **BUILD.gn**: Added `dts_gen` dependency (`dts_gen_${board}`) to both `blueos` and `kernel_unittest` targets. Added `DTS_OUT_DIR` rustenv variable so the generated module path is resolved at compile time via an environment variable instead of a hardcoded path.
- **mod.rs**: Added `include!(concat!(env!("DTS_OUT_DIR"), "/mod.rs"))` to pull in build-time generated device tree constants.

## Architecture

The `DTS_OUT_DIR` env var is set in GN via `rustenv` and points to `root_gen_dir/dts` (rebased to absolute path). This removes the hardcoded path dependency and makes the include portable across different build environments.

## Test Plan

- `ninja -C out/qemu_riscv64 check_all` — all 139 targets pass
- Unit tests and integration tests pass on `qemu_riscv64`

Co-authored-by: Claude Haiku 4.5 <noreply@anthropic.com>