### PR TITLE
driver: add ESP32-C3 hwinfo

### DIFF
--- a/driver/src/hwinfo/esp32c3.rs
+++ b/driver/src/hwinfo/esp32c3.rs
@@ -1,0 +1,56 @@
+// Copyright (c) 2026 vivo Mobile Communication Co., Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use crate::static_ref::StaticRef;
+use tock_registers::{interfaces::Readable, register_structs, registers::ReadOnly};
+
+const EFUSE_BASE: usize = 0x6000_8800;
+
+register_structs! {
+    /// Register block for the eFuse controller.
+    EfuseRegisters {
+        /// eFuse read control register.
+        (0x00 => _reserved0),
+        /// eFuse read data register.
+        (0x044 => rd_mac_spi_sys_0: ReadOnly<u32>),
+        (0x048 => rd_mac_spi_sys_1: ReadOnly<u32>),
+        (0x04C => rd_mac_spi_sys_2: ReadOnly<u32>),
+        (0x050 => rd_mac_spi_sys_3: ReadOnly<u32>),
+        (0x054 => rd_mac_spi_sys_4: ReadOnly<u32>),
+        (0x058 => rd_mac_spi_sys_5: ReadOnly<u32>),
+        /// Reserved space.
+        (0x05C => @END),
+    }
+}
+
+static EFUSE_REGISTERS: StaticRef<EfuseRegisters> =
+    unsafe { StaticRef::new(EFUSE_BASE as *const EfuseRegisters) };
+
+pub fn mac() -> [u8; 6] {
+    let mac0 = EFUSE_REGISTERS.rd_mac_spi_sys_0.get();
+
+    let mac1 = EFUSE_REGISTERS.rd_mac_spi_sys_1.get();
+
+    let mac1_bytes = mac1.to_le_bytes();
+    let mac0_bytes = mac0.to_le_bytes();
+
+    [
+        mac1_bytes[1],
+        mac1_bytes[0],
+        mac0_bytes[3],
+        mac0_bytes[2],
+        mac0_bytes[1],
+        mac0_bytes[0],
+    ]
+}

--- a/driver/src/hwinfo/mod.rs
+++ b/driver/src/hwinfo/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2025 vivo Mobile Communication Co., Ltd.
+// Copyright (c) 2026 vivo Mobile Communication Co., Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,15 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![no_std]
-#![feature(const_nonnull_new)]
-
-pub mod clock_control;
-pub mod hwinfo;
-pub mod i2c;
-pub mod interrupt_controller;
-pub mod pinctrl;
-pub mod reset;
-pub mod static_ref;
-pub mod systimer;
-pub mod uart;
+#[cfg(target_chip = "esp32c3")]
+pub mod esp32c3;


### PR DESCRIPTION
## Summary
- Add an ESP32-C3 hardware information module under the driver crate.
- Read the base MAC address from the ESP32-C3 eFuse registers.
- Export the new `hwinfo` module from the driver crate.

## Affected board/arch
- seeed_xiao_esp32c3.debug
- RISC-V ESP32-C3

## Tests
- `rustfmt driver/src/lib.rs driver/src/hwinfo/mod.rs driver/src/hwinfo/esp32c3.rs`
- `ninja -C out/seeed_xiao_esp32c3.debug/gen/apps/example/wifi`
- `ninja -C out/seeed_xiao_esp32c3.debug blueos_clippy kernel_unittest_clippy`
- `ninja -C out/seeed_xiao_esp32c3.debug check_all` *(blocked locally because `qemu-esp32-riscv32` is not installed; build, image generation, and clippy targets completed before the QEMU test runner step failed)*

## Notes
- No defconfig files were modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
