### PR TITLE
fix(uart): batch USB Serial JTAG TX, remove per-byte WR_DONE

### DIFF
--- a/driver/src/uart/esp32_usb_serial.rs
+++ b/driver/src/uart/esp32_usb_serial.rs
@@ -166,9 +166,6 @@ impl Has8bitDataReg for Esp32UsbSerial {
         USB_SERIAL_BASE
             .ep1_reg
             .write(EP1_REG::RDWR_BYTE.val(data as u32));
-        USB_SERIAL_BASE
-            .ep1_conf_reg
-            .write(EP1_CONF_REG::WR_DONE.val(1));
     }
 
     fn is_data_ready(&self) -> bool {
@@ -211,6 +208,12 @@ impl HasFifo for Esp32UsbSerial {
             .ep1_conf_reg
             .is_set(EP1_CONF_REG::OUT_EP_DATA_AVAIL)
             != true
+    }
+
+    fn flush_tx_fifo(&self) {
+        USB_SERIAL_BASE
+            .ep1_conf_reg
+            .write(EP1_CONF_REG::WR_DONE.val(1));
     }
 }
 

--- a/hal/src/lib.rs
+++ b/hal/src/lib.rs
@@ -146,6 +146,7 @@ pub trait HasFifo {
     fn enable_fifo(&self, num: u8) -> Result<()>;
     fn is_tx_fifo_full(&self) -> bool;
     fn is_rx_fifo_empty(&self) -> bool;
+    fn flush_tx_fifo(&self) {}
 }
 
 /// Status register operations trait

--- a/kernel/src/console.rs
+++ b/kernel/src/console.rs
@@ -57,12 +57,13 @@ impl fmt::Write for Console {
 pub struct EarlyConsole;
 impl fmt::Write for EarlyConsole {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
-        use blueos_hal::{Has8bitDataReg, HasLineStatusReg};
+        use blueos_hal::{Has8bitDataReg, HasFifo, HasLineStatusReg};
         let _guard = DisableInterruptGuard::new();
         let uart = crate::boards::get_device!(console_uart);
         for byte in s.as_bytes() {
             while uart.is_bus_busy() {}
             uart.write_data8(*byte);
+            uart.flush_tx_fifo();
         }
         Ok(())
     }

--- a/kernel/src/drivers/serial/mod.rs
+++ b/kernel/src/drivers/serial/mod.rs
@@ -334,6 +334,8 @@ impl Serial {
     fn send_byte_polling(&self, c: u8) {
         while self.dev.is_tx_fifo_full() {}
         self.dev.write_data8(c);
+        use blueos_hal::HasFifo;
+        self.dev.flush_tx_fifo();
     }
 
     #[inline(always)]
@@ -363,7 +365,9 @@ impl Serial {
         // as there is no previous. But it's not common in MCU where TX is usually
         // a level interrupt, active for as long as TX buffer is empty. So we should
         // consider to make this behavior configurable in the future.
-        self.consumer_byte();
+        while self.consumer_byte() {}
+        use blueos_hal::HasFifo;
+        self.dev.flush_tx_fifo();
     }
 
     #[inline(always)]
@@ -429,12 +433,13 @@ impl Serial {
 
     /// only be used in irq handler
     pub(crate) fn xmitchars(&self) {
-        use blueos_hal::HasInterruptReg;
+        use blueos_hal::{HasFifo, HasInterruptReg};
 
         #[cfg(smp)]
         let _lock = self.critical_section_guard.irqsave_lock();
 
-        self.consumer_byte();
+        while self.consumer_byte() {}
+        self.dev.flush_tx_fifo();
     }
 
     /// only be used in irq handler


### PR DESCRIPTION
# Fix: batch USB Serial JTAG TX writes, remove per-byte WR_DONE

## Problem

On ESP32-C3-DevKit-Rust-1, the `help` command in the kernel shell
produces garbled output — newlines are lost from line 5 onward,
causing text concatenation/overwriting on the terminal.

Actual output:

```
Hello, shell!
> help
BlueOS kernel shell commands:
  help       - Use help [command] view help for a specific command
  cat        - Concatenate file(s) to standard output, usage: cat [<path> [<path> [<path> ...]]]
  touch      - Update the access and modification times of each file to the current time, usage: touch <fil  echo        rmdir  ls         -  cd         - Switch  cp         - Copy source to  trunca  dealloc    mount      - Mou  ps      umount     -  mkdir      - Create direct  printf     - Formats and prints a  alloc      - Allocate memory   pwd        - Print the current working directory
  cmp        - Compare two files byte by  free       - Display the amount of free and used>
```

## Reproduction

```bash
#!/bin/bash
# Prerequisites:
#   - ESP32-C3-DevKit-Rust-1 connected via USB
#   - espflash installed
#   - rustup default blueos
#   - ninja, gn in PATH

set -euo pipefail

BLUEKERNEL_ROOT="/path/to/bluekernel"
cd "$BLUEKERNEL_ROOT"

# Build
echo "[1/3] Building..."
gn gen out/seeed_xiao_esp32c3.debug --args='build_type="debug" board="seeed_xiao_esp32c3"'
ninja -C out/seeed_xiao_esp32c3.debug shell 2>&1 | tail -5

# Flash + monitor in tmux
echo "[2/3] Flashing to ESP32-C3..."
tmux kill-session -t esp32 2>/dev/null || true
sleep 1
tmux new-session -d -s esp32 \
  "espflash flash --monitor out/seeed_xiao_esp32c3.debug/bin/shell"
sleep 18

# Send help and capture
echo "[3/3] Running help command..."
tmux resize-pane -t esp32 -y 100 -x 300
tmux send-keys -t esp32 "help" Enter
sleep 3

OUTPUT=$(tmux capture-pane -t esp32 -p -S -40)

echo "$OUTPUT"
```

## Root Cause

Two compounding defects:

1. `Esp32UsbSerial::write_data8()` sets `WR_DONE` after every single
   byte, forcing each byte into its own USB IN transaction.

2. `xmitchars()` only consumes one byte per TX interrupt.

This creates the following causal chain:

- Each TX interrupt drains only 1 byte from the ring buffer into the
  hardware FIFO, then sets WR_DONE, causing an immediate USB IN
  transaction for that single byte.
- The USB host must ACK each IN transaction before `IN_EP_DATA_FREE`
  returns to 1, allowing the next byte to be written.
- For 16 lines of help output (~500+ bytes), this requires 500+ TX
  interrupts and 500+ USB IN transactions, with each transaction
  carrying only 1 byte instead of up to 64.
- USB Serial JTAG has **no hardware flow control**. When the host
  terminal emulator cannot process IN transactions fast enough (USB
  scheduling, host-side buffer processing), the device has no way to
  back-pressure. The hardware FIFO backs up and bytes are overwritten
  before the host consumes them.
- Bytes are overwritten during the congested window, causing characters to
  disappear and subsequent lines to concatenate on the terminal.

## Fix

Separate `write_data8` (write byte only) from `flush_tx_fifo` (notify
hardware to send). In
interrupt-driven paths, drain the entire ring buffer into the hardware
FIFO in one go before flushing, instead of consuming one byte per
interrupt. In polling paths (EarlyConsole, send_byte_polling), keep
per-byte flush to avoid FIFO-full deadlock since no interrupt will
drain the FIFO.

Reference: [ESP-IDF Issue #11192](https://github.com/espressif/esp-idf/issues/11192)
