### PR TITLE
kernel: allow yield_now during async poll

### DIFF
--- a/kernel/src/asynk/mod.rs
+++ b/kernel/src/asynk/mod.rs
@@ -42,7 +42,7 @@ impl_simple_intrusive_adapter!(TaskletLock, Tasklet, lock);
 pub struct Tasklet {
     node: IlistHead<Tasklet, TaskletNode>,
     lock: ISpinLock<Tasklet, TaskletLock>,
-    future: Pin<Box<dyn Future<Output = ()>>>,
+    future: Option<Pin<Box<dyn Future<Output = ()>>>>,
     blocked: Option<ThreadNode>,
     state: AtomicUsize,
 }
@@ -51,7 +51,7 @@ impl Tasklet {
     pub fn new(future: Pin<Box<dyn Future<Output = ()>>>) -> Self {
         Self {
             node: IlistHead::new(),
-            future,
+            future: Some(future),
             lock: ISpinLock::new(),
             blocked: None,
             state: AtomicUsize::new(TASKLET_IDLE),
@@ -240,21 +240,30 @@ fn poll_inner() {
         );
         debug_assert_eq!(old, Ok(TASKLET_QUEUED));
 
+        let mut future = {
+            let mut l = task.lock();
+            l.future.take().expect("tasklet future is missing")
+        };
+
         let waker = tasklet_waker(task.clone());
         let mut ctx = Context::from_waker(&waker);
-        let mut l = task.lock();
-        match l.future.as_mut().poll(&mut ctx) {
+        match future.as_mut().poll(&mut ctx) {
             Poll::Ready(()) => {
-                task.state.store(TASKLET_COMPLETED, Ordering::Release);
-                let blocked = l.blocked.take();
-                drop(l);
+                let blocked = {
+                    let mut l = task.lock();
+                    task.state.store(TASKLET_COMPLETED, Ordering::Release);
+                    l.blocked.take()
+                };
                 if let Some(t) = blocked {
                     let ok = scheduler::queue_ready_thread(thread::SUSPENDED, t);
                     debug_assert_eq!(ok, Ok(()));
                 }
             }
             Poll::Pending => {
-                drop(l);
+                {
+                    let mut l = task.lock();
+                    l.future = Some(future);
+                }
                 finish_pending_poll(task);
             }
         }


### PR DESCRIPTION
## Summary
- Move tasklet futures out of the tasklet lock before polling them.
- Store pending futures back after poll returns `Pending`, while completed tasklets keep the future consumed.
- Allow async tasks to call `yield_now()` during polling without re-entering the tasklet lock.

## Affected Area
- Kernel async tasklet executor (`kernel/src/asynk/mod.rs`)

## Test Plan
- `git -C /home/xuchang/blueos-github/kernel diff --check origin/main...HEAD`
- `export PATH="/home/xuchang/.rustup/toolchains/blueos-latest/bin:$PATH"; rustfmt --check /home/xuchang/blueos-github/kernel/kernel/src/asynk/mod.rs`
- Verified `kernel/src/asynk/channel_issues.md` is not part of the branch diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
