### PR TITLE
Add Backspace key recognition in Windows.

### DIFF
--- a/kernel/src/devices/tty/n_tty.rs
+++ b/kernel/src/devices/tty/n_tty.rs
@@ -244,7 +244,7 @@ impl Device for Tty {
                     }
                     return Ok(0);
                 }
-                if erase_char == ch {
+                if erase_char == ch || ch == 0x08 {
                     if cursor > 0 {
                         let backspace_seq = [8u8, b' ', 8u8];
                         self.dev.send_bytes(&backspace_seq, false)?;


### PR DESCRIPTION
The ASCII code for the Backspace key in Windows differs from that in Linux, causing the development board to be unable to delete characters entered in the shell even after forwarding the message to WSL via the interface.