### PR TITLE
net: remove closed sockets from network manager

### DIFF
--- a/kernel/src/net/connection.rs
+++ b/kernel/src/net/connection.rs
@@ -491,9 +491,11 @@ impl Connection {
                         socket_fd,
                         ipc_reply.clone(),
                         |posix_socket| {
-                            let mut posix_socket = posix_socket.borrow_mut();
-
-                            Some(posix_socket.shutdown())
+                            let result = posix_socket.borrow().shutdown();
+                            if result.is_ok() {
+                                network_manager.borrow_mut().remove_posix_socket(socket_fd);
+                            }
+                            Some(result)
                         },
                     );
                 }

--- a/kernel/src/net/connection.rs
+++ b/kernel/src/net/connection.rs
@@ -394,7 +394,8 @@ impl Connection {
         ipc_reply: Arc<OperationIPCReply>,
         f: F,
     ) {
-        if let Some(posix_socket) = network_manager.borrow_mut().get_posix_socket(socket_fd) {
+        let posix_socket = { network_manager.borrow().get_posix_socket(socket_fd) };
+        if let Some(posix_socket) = posix_socket {
             if posix_socket.borrow().is_shutdown() {
                 log::debug!("Socket {} already shutdown", socket_fd);
                 return;
@@ -491,7 +492,10 @@ impl Connection {
                         socket_fd,
                         ipc_reply.clone(),
                         |posix_socket| {
-                            let result = posix_socket.borrow().shutdown();
+                            let result = {
+                                let posix_socket = posix_socket.borrow();
+                                posix_socket.shutdown()
+                            };
                             if result.is_ok() {
                                 network_manager.borrow_mut().remove_posix_socket(socket_fd);
                             }

--- a/kernel/src/net/net_manager.rs
+++ b/kernel/src/net/net_manager.rs
@@ -123,6 +123,13 @@ impl NetworkManager {
         self.socket_maps.get(&socket_fd).cloned()
     }
 
+    pub fn remove_posix_socket(
+        &mut self,
+        socket_fd: SocketFd,
+    ) -> Option<Rc<RefCell<dyn PosixSocket + 'static>>> {
+        self.socket_maps.remove(&socket_fd)
+    }
+
     pub fn loop_within_single_thread<F>(
         network_manager: Rc<RefCell<NetworkManager>>,
         timeout_millis: usize,


### PR DESCRIPTION
## Summary
- Remove the network-manager mapping after a socket shutdown succeeds.
- Prevent stale closed sockets from remaining addressable by the numeric socket fd.

## Testing
- `git diff --check`
- `ninja -C out/qemu_mps2_an385.debug obj/kernel/kernel/blueos/libblueos.rlib` (already up to date)

## Scope
- This PR contains only the socket-map cleanup; the separate accept implementation is not included.