### PR TITLE
net: fix accept syscall parameter types

### DIFF
--- a/kernel/src/net/syscalls.rs
+++ b/kernel/src/net/syscalls.rs
@@ -563,8 +563,8 @@ pub fn getsockopt(
 
 pub fn accept(
     socket: c_int,
-    _address: *const libc::sockaddr,
-    _address_len: libc::socklen_t,
+    _address: *mut libc::sockaddr,
+    _address_len: *mut libc::socklen_t,
 ) -> c_int {
     log::debug!("fd={}: Accepting connection", socket);
 

--- a/kernel/src/syscall_handlers/mod.rs
+++ b/kernel/src/syscall_handlers/mod.rs
@@ -136,7 +136,7 @@ mod net_syscalls {
     pub fn listen(_socket: c_int, _backlog: c_int) -> c_int {
         -libc::ENOTSUP
     }
-    pub fn accept(_socket: c_int, _address: *const sockaddr, _address_len: u32) -> c_int {
+    pub fn accept(_socket: c_int, _address: *mut sockaddr, _address_len: *mut socklen_t) -> c_int {
         -libc::ENOTSUP
     }
     pub fn send(
@@ -689,18 +689,7 @@ define_syscall_handler!(
 
 define_syscall_handler!(
     accept(sockfd: c_int, addr: *mut sockaddr, len: *mut socklen_t) -> c_int {
-        let orig_len = if !len.is_null() { unsafe { *len } } else { 0 };
-
-        let result = net_syscalls::accept(
-            sockfd,
-            addr as *const sockaddr,
-            orig_len
-        );
-        if !len.is_null() && result >= 0 {
-            unsafe { *len = orig_len };
-        }
-
-        result
+        net_syscalls::accept(sockfd, addr, len)
     }
 );
 


### PR DESCRIPTION
## Summary
- Match the kernel `accept` syscall implementation with the POSIX ABI: `struct sockaddr *` and `socklen_t *`.
- Pass both user pointers through the syscall handler unchanged.
- Remove the stale length-value conversion and writeback logic.

## Why these types
The POSIX declaration is:

```c
int accept(int socket, struct sockaddr *restrict address,
           socklen_t *restrict address_len);
```

- `address` must be `*mut sockaddr` because it is an output buffer. On a successful accept, the kernel writes the connected peer address into caller-owned memory. A `*const sockaddr` incorrectly describes that memory as read-only.
- `address_len` must be `*mut socklen_t` because it is an input/output parameter. On entry, `*address_len` is the capacity of the address buffer; on return, the kernel stores the actual peer-address length there. Passing `socklen_t` by value loses the caller pointer and prevents the networking implementation from updating it correctly.
- Passing the pointers unchanged through the syscall handler preserves the userspace ABI and leaves validation and bounded address copying to the networking syscall implementation.

## Testing
- `rustfmt --check kernel/src/net/syscalls.rs kernel/src/syscall_handlers/mod.rs`
- `git diff --check`
- `ninja -C out/qemu_mps2_an385.debug obj/kernel/kernel/blueos/libblueos.rlib`

## Scope
- This PR only fixes the `accept` syscall parameter types. It does not include the TCP accept implementation or socket-map cleanup.