### PR TITLE
net: implement TCP accept syscall

### DIFF
--- a/kernel/src/net/connection.rs
+++ b/kernel/src/net/connection.rs
@@ -344,6 +344,9 @@ impl Connection {
                 let mut endpoint = self.local_endpoint.lock();
                 if endpoint.is_none() {
                     let local_port = PORT_GENERATOR.acquire_port(self.socket_type, 0)?;
+                    self.local_port_lease
+                        .lock()
+                        .replace(PortLease::new(self.socket_type, local_port));
                     endpoint.replace((local_port).into());
                     Some(local_port)
                 } else {

--- a/kernel/src/net/connection.rs
+++ b/kernel/src/net/connection.rs
@@ -43,14 +43,33 @@ use spin::Mutex;
 // For posix syscalls
 pub type ConnectionResult = Result<usize, ConnectionError>;
 
+struct PortLease {
+    socket_type: SocketType,
+    port: u16,
+}
+
+impl PortLease {
+    fn new(socket_type: SocketType, port: u16) -> Arc<Self> {
+        Arc::new(Self { socket_type, port })
+    }
+}
+
+impl Drop for PortLease {
+    fn drop(&mut self) {
+        let _ = PORT_GENERATOR.release_port(self.socket_type, self.port);
+    }
+}
+
 pub struct Connection {
     socket_fd: SocketFd,
     socket_domain: SocketDomain,
     socket_type: SocketType,
     socket_protocol: SocketProtocol,
     local_endpoint: Mutex<Option<IpListenEndpoint>>,
+    local_port_lease: Mutex<Option<Arc<PortLease>>>,
     remote_endpoint: Mutex<Option<IpEndpoint>>,
     is_nonblocking: AtomicBool, // default io mode is blocking, use O_NONBLOCK to set non-blocking
+    is_listening: AtomicBool,
     recv_timeout: Mutex<Option<Duration>>, // block indefinitely as default
     send_timeout: Mutex<Option<Duration>>, // block indefinitely as default
     ipc_reply: Arc<OperationIPCReply>,
@@ -69,8 +88,10 @@ impl Connection {
             socket_type,
             socket_protocol,
             local_endpoint: Mutex::new(None),
+            local_port_lease: Mutex::new(None),
             remote_endpoint: Mutex::new(None),
             is_nonblocking: AtomicBool::new(false),
+            is_listening: AtomicBool::new(false),
             recv_timeout: Mutex::new(None),
             send_timeout: Mutex::new(None),
             ipc_reply: Arc::new(OperationIPCReply::new()),
@@ -114,7 +135,12 @@ impl Connection {
                     self.socket_type,
                     SocketType::SockStream | SocketType::SockDgram
                 ) {
-                    PORT_GENERATOR.acquire_port(self.socket_type, local_endpoint.port)?
+                    let port =
+                        PORT_GENERATOR.acquire_port(self.socket_type, local_endpoint.port)?;
+                    self.local_port_lease
+                        .lock()
+                        .replace(PortLease::new(self.socket_type, port));
+                    port
                 } else {
                     local_endpoint.port
                 };
@@ -154,7 +180,56 @@ impl Connection {
         log::debug!("[Socket {}] Listen request queued", self.socket_fd);
 
         // Wait for network stack response and return directly
-        self.ipc_reply.queue_and_wait(listen_task)
+        let result = self.ipc_reply.queue_and_wait(listen_task);
+        if result.is_ok() {
+            self.is_listening.store(true, Ordering::Release);
+        }
+        result
+    }
+
+    pub fn new_accepted(socket_fd: SocketFd, listener: &Connection) -> Self {
+        let accepted = Self::new(
+            socket_fd,
+            listener.socket_domain,
+            listener.socket_type,
+            listener.socket_protocol,
+        );
+        *accepted.local_endpoint.lock() = *listener.local_endpoint.lock();
+        *accepted.local_port_lease.lock() = listener.local_port_lease.lock().clone();
+        accepted
+    }
+
+    pub fn set_remote_endpoint(&self, endpoint: IpEndpoint) {
+        self.remote_endpoint.lock().replace(endpoint);
+    }
+
+    pub fn remote_endpoint(&self) -> Option<IpEndpoint> {
+        *self.remote_endpoint.lock()
+    }
+
+    pub fn is_listening(&self) -> bool {
+        self.is_listening.load(Ordering::Acquire)
+    }
+
+    pub fn accept(
+        &self,
+        accepted_fd: SocketFd,
+        accepted_connection: Arc<Connection>,
+    ) -> ConnectionResult {
+        let local_endpoint = match *self.local_endpoint.lock() {
+            Some(endpoint) => endpoint,
+            None => return Err(ConnectionError::LockFail("local endpoint".into())),
+        };
+        let accept_task = Operation::Accept {
+            socket_fd: self.socket_fd,
+            accepted_fd,
+            local_endpoint,
+            accepted_connection,
+            is_nonblocking: self.is_nonblocking.load(Ordering::Acquire),
+            ipc_reply: self.ipc_reply.clone(),
+        };
+
+        self.ipc_reply.queue_and_wait(accept_task)
     }
 
     pub fn connect(&self, remote_endpoint: IpEndpoint) -> ConnectionResult {
@@ -165,6 +240,9 @@ impl Connection {
                 Some(endpoint) => endpoint.port,
                 None => {
                     let port = PORT_GENERATOR.acquire_port(SocketType::SockStream, 0)?;
+                    self.local_port_lease
+                        .lock()
+                        .replace(PortLease::new(self.socket_type, port));
                     local_endpoint.replace(port.into());
                     port
                 }
@@ -187,6 +265,7 @@ impl Connection {
     }
 
     pub fn shutdown(&self) -> ConnectionResult {
+        self.is_listening.store(false, Ordering::Release);
         // Construct shutdown request with cloned response channel
         let shutdown_task = Operation::Shutdown {
             socket_fd: self.socket_fd,
@@ -384,8 +463,7 @@ impl Connection {
     }
 
     pub fn is_connected(&self) -> bool {
-        // Client connect or Server bound
-        self.remote_endpoint.lock().is_some() || self.local_endpoint.lock().is_some()
+        self.remote_endpoint.lock().is_some()
     }
 
     fn with_posix_socket<F: FnOnce(Rc<RefCell<dyn PosixSocket>>) -> Option<OperationResult>>(
@@ -398,6 +476,13 @@ impl Connection {
         if let Some(posix_socket) = posix_socket {
             if posix_socket.borrow().is_shutdown() {
                 log::debug!("Socket {} already shutdown", socket_fd);
+                ipc_reply.wakeup_client(
+                    Err(SocketError::PosixError(
+                        -libc::ECONNABORTED,
+                        "socket is shut down".into(),
+                    )),
+                    socket_fd,
+                );
                 return;
             }
 
@@ -447,6 +532,48 @@ impl Connection {
                         |posix_socket| {
                             let mut posix_socket = posix_socket.borrow_mut();
                             Some(posix_socket.listen(local_endpoint))
+                        },
+                    )
+                }
+                Operation::Accept {
+                    socket_fd,
+                    accepted_fd,
+                    local_endpoint,
+                    accepted_connection,
+                    is_nonblocking,
+                    ipc_reply,
+                } => {
+                    log::debug!(
+                        "[Connection] handle Accept socket_fd={} accepted_fd={}",
+                        socket_fd,
+                        accepted_fd
+                    );
+
+                    Connection::with_posix_socket(
+                        network_manager.clone(),
+                        socket_fd,
+                        ipc_reply.clone(),
+                        |posix_socket| {
+                            let result = posix_socket.borrow_mut().accept(
+                                accepted_fd,
+                                local_endpoint,
+                                accepted_connection.clone(),
+                                is_nonblocking,
+                                ipc_reply.clone(),
+                            );
+
+                            match result {
+                                Ok(accepted) => {
+                                    accepted_connection
+                                        .set_remote_endpoint(accepted.remote_endpoint);
+                                    network_manager
+                                        .borrow_mut()
+                                        .insert_posix_socket(accepted_fd, accepted.socket);
+                                    Some(Ok(accepted_fd as usize))
+                                }
+                                Err(SocketError::WouldBlock) => None,
+                                Err(error) => Some(Err(error)),
+                            }
                         },
                     )
                 }
@@ -754,15 +881,6 @@ impl Connection {
     }
 }
 
-impl Drop for Connection {
-    fn drop(&mut self) {
-        // Release local port
-        if let Some(local_port) = *self.local_endpoint.lock() {
-            let _ = PORT_GENERATOR.release_port(self.socket_type, local_port.port);
-        }
-    }
-}
-
 // MPSC Queue from heapless requires CAS atomic instructions which are not available on all architectures
 pub static NETSTACK_QUEUE: heapless::mpmc::MpMcQueue<Operation, 32> =
     heapless::mpmc::MpMcQueue::<Operation, 32>::new();
@@ -898,6 +1016,15 @@ pub enum Operation {
     Listen {
         socket_fd: SocketFd,
         local_endpoint: IpListenEndpoint,
+        ipc_reply: Arc<OperationIPCReply>,
+    },
+
+    Accept {
+        socket_fd: SocketFd,
+        accepted_fd: SocketFd,
+        local_endpoint: IpListenEndpoint,
+        accepted_connection: Arc<Connection>,
+        is_nonblocking: bool,
         ipc_reply: Arc<OperationIPCReply>,
     },
 

--- a/kernel/src/net/connection.rs
+++ b/kernel/src/net/connection.rs
@@ -70,7 +70,6 @@ pub struct Connection {
     remote_endpoint: Mutex<Option<IpEndpoint>>,
     is_nonblocking: AtomicBool, // default io mode is blocking, use O_NONBLOCK to set non-blocking
     is_listening: AtomicBool,
-    reuse_address: AtomicBool,
     recv_timeout: Mutex<Option<Duration>>, // block indefinitely as default
     send_timeout: Mutex<Option<Duration>>, // block indefinitely as default
     ipc_reply: Arc<OperationIPCReply>,
@@ -93,7 +92,6 @@ impl Connection {
             remote_endpoint: Mutex::new(None),
             is_nonblocking: AtomicBool::new(false),
             is_listening: AtomicBool::new(false),
-            reuse_address: AtomicBool::new(false),
             recv_timeout: Mutex::new(None),
             send_timeout: Mutex::new(None),
             ipc_reply: Arc::new(OperationIPCReply::new()),
@@ -198,10 +196,6 @@ impl Connection {
         );
         *accepted.local_endpoint.lock() = *listener.local_endpoint.lock();
         *accepted.local_port_lease.lock() = listener.local_port_lease.lock().clone();
-        accepted.reuse_address.store(
-            listener.reuse_address.load(Ordering::Acquire),
-            Ordering::Release,
-        );
         accepted
     }
 
@@ -271,7 +265,6 @@ impl Connection {
     }
 
     pub fn shutdown(&self) -> ConnectionResult {
-        self.is_listening.store(false, Ordering::Release);
         // Construct shutdown request with cloned response channel
         let shutdown_task = Operation::Shutdown {
             socket_fd: self.socket_fd,
@@ -282,7 +275,11 @@ impl Connection {
         log::debug!("[Socket {}] Shutdown request queued", self.socket_fd);
 
         // Await and return final shutdown status from network stack
-        self.ipc_reply.queue_and_wait(shutdown_task)
+        let result = self.ipc_reply.queue_and_wait(shutdown_task);
+        if result.is_ok() {
+            self.is_listening.store(false, Ordering::Release);
+        }
+        result
     }
 
     pub fn recv(&self, f: FnRecv) -> ConnectionResult {
@@ -432,14 +429,6 @@ impl Connection {
     // Set recv timeout : ref to libc::SO_RCVTIMEO
     pub fn set_recv_timeout(&self, timeout: Duration) {
         self.recv_timeout.lock().replace(timeout);
-    }
-
-    pub fn set_reuse_address(&self, reuse_address: bool) {
-        self.reuse_address.store(reuse_address, Ordering::Release);
-    }
-
-    pub fn reuse_address(&self) -> bool {
-        self.reuse_address.load(Ordering::Acquire)
     }
 
     // Set send timeout : ref to libc::SO_SNDTIMEO

--- a/kernel/src/net/connection.rs
+++ b/kernel/src/net/connection.rs
@@ -958,7 +958,7 @@ impl OperationIPCReply {
                 return result.map_err(Into::into);
             }
 
-            if !self.reply_futex.load(Ordering::Acquire) == STATE_WAITING_FOR_CONSUME {
+            if self.reply_futex.load(Ordering::Acquire) != STATE_WAITING_FOR_CONSUME {
                 yield_me();
                 continue;
             }

--- a/kernel/src/net/connection.rs
+++ b/kernel/src/net/connection.rs
@@ -70,6 +70,7 @@ pub struct Connection {
     remote_endpoint: Mutex<Option<IpEndpoint>>,
     is_nonblocking: AtomicBool, // default io mode is blocking, use O_NONBLOCK to set non-blocking
     is_listening: AtomicBool,
+    reuse_address: AtomicBool,
     recv_timeout: Mutex<Option<Duration>>, // block indefinitely as default
     send_timeout: Mutex<Option<Duration>>, // block indefinitely as default
     ipc_reply: Arc<OperationIPCReply>,
@@ -92,6 +93,7 @@ impl Connection {
             remote_endpoint: Mutex::new(None),
             is_nonblocking: AtomicBool::new(false),
             is_listening: AtomicBool::new(false),
+            reuse_address: AtomicBool::new(false),
             recv_timeout: Mutex::new(None),
             send_timeout: Mutex::new(None),
             ipc_reply: Arc::new(OperationIPCReply::new()),
@@ -196,6 +198,10 @@ impl Connection {
         );
         *accepted.local_endpoint.lock() = *listener.local_endpoint.lock();
         *accepted.local_port_lease.lock() = listener.local_port_lease.lock().clone();
+        accepted.reuse_address.store(
+            listener.reuse_address.load(Ordering::Acquire),
+            Ordering::Release,
+        );
         accepted
     }
 
@@ -423,6 +429,14 @@ impl Connection {
     // Set recv timeout : ref to libc::SO_RCVTIMEO
     pub fn set_recv_timeout(&self, timeout: Duration) {
         self.recv_timeout.lock().replace(timeout);
+    }
+
+    pub fn set_reuse_address(&self, reuse_address: bool) {
+        self.reuse_address.store(reuse_address, Ordering::Release);
+    }
+
+    pub fn reuse_address(&self) -> bool {
+        self.reuse_address.load(Ordering::Acquire)
     }
 
     // Set send timeout : ref to libc::SO_SNDTIMEO

--- a/kernel/src/net/connection.rs
+++ b/kernel/src/net/connection.rs
@@ -950,7 +950,7 @@ impl OperationIPCReply {
                 return result.map_err(Into::into);
             }
 
-            if self.reply_futex.load(Ordering::Acquire) != STATE_WAITING_FOR_CONSUME {
+            if !self.reply_futex.load(Ordering::Acquire) == STATE_WAITING_FOR_CONSUME {
                 yield_me();
                 continue;
             }

--- a/kernel/src/net/connection.rs
+++ b/kernel/src/net/connection.rs
@@ -245,7 +245,7 @@ impl Connection {
             match local_endpoint {
                 Some(endpoint) => endpoint.port,
                 None => {
-                    let port = PORT_GENERATOR.acquire_port(SocketType::SockStream, 0)?;
+                    let port = PORT_GENERATOR.acquire_port(self.socket_type, 0)?;
                     self.local_port_lease
                         .lock()
                         .replace(PortLease::new(self.socket_type, port));

--- a/kernel/src/net/connection_err.rs
+++ b/kernel/src/net/connection_err.rs
@@ -53,6 +53,22 @@ pub enum ConnectionError {
     SocketOperationError(SocketError),
 }
 
+impl ConnectionError {
+    pub fn to_errno(&self) -> i32 {
+        match self {
+            Self::SocketOperationError(error) => error.to_errno(),
+            Self::NetStackQueueFull => -libc::EAGAIN,
+            Self::PosixError(error) => error.to_errno(),
+            Self::UnsupportedSocketType(_) => -libc::EOPNOTSUPP,
+            Self::NoAvailableDynamicPort => -libc::EADDRNOTAVAIL,
+            Self::PortInUse(_) => -libc::EADDRINUSE,
+            Self::PortOutOfRange(_, _) => -libc::EINVAL,
+            Self::Timeout(_) => -libc::ETIMEDOUT,
+            Self::LockFail(_) => -libc::EIO,
+        }
+    }
+}
+
 impl From<SocketError> for ConnectionError {
     fn from(err: SocketError) -> Self {
         Self::SocketOperationError(err)

--- a/kernel/src/net/net_manager.rs
+++ b/kernel/src/net/net_manager.rs
@@ -123,6 +123,14 @@ impl NetworkManager {
         self.socket_maps.get(&socket_fd).cloned()
     }
 
+    pub fn insert_posix_socket(
+        &mut self,
+        socket_fd: SocketFd,
+        socket: Rc<RefCell<dyn PosixSocket + 'static>>,
+    ) {
+        self.socket_maps.insert(socket_fd, socket);
+    }
+
     pub fn remove_posix_socket(
         &mut self,
         socket_fd: SocketFd,

--- a/kernel/src/net/smoltcp/socket/icmp.rs
+++ b/kernel/src/net/smoltcp/socket/icmp.rs
@@ -105,7 +105,14 @@ impl PosixSocket for IcmpSocket {
         self.smoltcp_interface.replace(interface.clone());
     }
 
-    fn accept(&self, _local_endpoint: IpListenEndpoint) -> SocketResult {
+    fn accept(
+        &mut self,
+        _accepted_fd: crate::net::SocketFd,
+        _local_endpoint: IpListenEndpoint,
+        _accepted_connection: Arc<crate::net::connection::Connection>,
+        _is_nonblocking: bool,
+        _ipc_reply: Arc<OperationIPCReply>,
+    ) -> crate::net::socket::AcceptResult {
         Err(SocketError::UnsupportedSocketTypeForOperation(
             SocketType::SockRaw,
             "accept()".into(),

--- a/kernel/src/net/smoltcp/socket/tcp.rs
+++ b/kernel/src/net/smoltcp/socket/tcp.rs
@@ -16,8 +16,8 @@ use crate::net::{
     connection::{Operation, OperationIPCReply, OperationResult},
     net_manager::NetworkManager,
     socket::{
-        socket_err::SocketError, socket_waker, FnRecv, FnRecvWithEndpoint, FnSend, FnSendMsg,
-        PosixSocket,
+        socket_err::SocketError, socket_waker, AcceptResult, AcceptedSocket, FnRecv,
+        FnRecvWithEndpoint, FnSend, FnSendMsg, PosixSocket,
     },
     SocketDomain, SocketFd, SocketProtocol, SocketResult, SocketType,
 };
@@ -83,19 +83,52 @@ impl TcpSocket {
         }
     }
 
-    pub fn with<F>(&mut self, f: F) -> SocketResult
+    pub fn with<F, R>(&mut self, f: F) -> Result<R, SocketError>
     where
-        F: FnOnce(&mut tcp::Socket<'static>, &mut Interface) -> SocketResult,
+        F: FnOnce(&mut tcp::Socket<'static>, &mut Interface) -> Result<R, SocketError>,
     {
         match &self.smoltcp_interface {
             Some(iface) => {
                 let handle = self
                     .smoltcp_socket_handle
                     .ok_or(SocketError::InvalidHandle)?;
-                iface.with_socket::<tcp::Socket<'static>, F, usize>(handle, f)
+                iface.with_socket::<tcp::Socket<'static>, F, R>(handle, f)
             }
             None => Err(SocketError::InterfaceNoAvailable),
         }
+    }
+
+    fn wait_for_accept(
+        &mut self,
+        accepted_fd: SocketFd,
+        local_endpoint: IpListenEndpoint,
+        accepted_connection: Arc<crate::net::connection::Connection>,
+        is_nonblocking: bool,
+        ipc_reply: Arc<OperationIPCReply>,
+    ) -> AcceptResult {
+        if is_nonblocking {
+            return Err(SocketError::TryAgain);
+        }
+
+        let accept_operation = Operation::Accept {
+            socket_fd: self.socket_fd,
+            accepted_fd,
+            local_endpoint,
+            accepted_connection,
+            is_nonblocking,
+            ipc_reply: ipc_reply.clone(),
+        };
+        let waker = socket_waker::create_closure_waker(
+            "TCP accept()".into(),
+            Some(accept_operation),
+            self.is_shutdown.clone(),
+        );
+        self.with(|socket, _| {
+            socket.register_recv_waker(&waker);
+            Ok(())
+        })?;
+
+        Err(SocketError::WouldBlock)
     }
 }
 
@@ -105,11 +138,90 @@ impl PosixSocket for TcpSocket {
         self.smoltcp_interface.replace(interface.clone());
     }
 
-    fn accept(&self, _local_endpoint: IpListenEndpoint) -> SocketResult {
-        Err(SocketError::UnsupportedSocketTypeForOperation(
-            SocketType::SockStream,
-            "use listen() for each connection".into(),
-        ))
+    fn accept(
+        &mut self,
+        accepted_fd: SocketFd,
+        local_endpoint: IpListenEndpoint,
+        accepted_connection: Arc<crate::net::connection::Connection>,
+        is_nonblocking: bool,
+        ipc_reply: Arc<OperationIPCReply>,
+    ) -> AcceptResult {
+        let (state, local_endpoint_connected, remote_endpoint) = self.with(|socket, _| {
+            Ok((
+                socket.state(),
+                socket.local_endpoint(),
+                socket.remote_endpoint(),
+            ))
+        })?;
+
+        match state {
+            State::Listen | State::SynReceived => {
+                return self.wait_for_accept(
+                    accepted_fd,
+                    local_endpoint,
+                    accepted_connection,
+                    is_nonblocking,
+                    ipc_reply,
+                );
+            }
+            State::Established | State::CloseWait => {}
+            _ => {
+                return Err(SocketError::InvalidState(format!(
+                    "TCP state[{}] cannot accept a connection",
+                    state
+                )));
+            }
+        }
+
+        let remote_endpoint = remote_endpoint.ok_or_else(|| {
+            SocketError::InvalidState("accepted socket has no remote endpoint".into())
+        })?;
+        let local_endpoint_connected = local_endpoint_connected.ok_or_else(|| {
+            SocketError::InvalidState("accepted socket has no local endpoint".into())
+        })?;
+        let interface = self
+            .smoltcp_interface
+            .clone()
+            .ok_or(SocketError::InterfaceNoAvailable)?;
+        let old_handle = self
+            .smoltcp_socket_handle
+            .take()
+            .ok_or(SocketError::InvalidHandle)?;
+
+        // The established handle becomes the accepted socket. The listening fd gets
+        // a fresh handle so it remains usable for the next connection.
+        let new_listener_handle = match self.create_smoltcp_socket() {
+            Some(handle) => handle,
+            None => {
+                self.smoltcp_socket_handle = Some(old_handle);
+                return Err(SocketError::CreateSmoltcpSocketFail);
+            }
+        };
+
+        let listen_result = self.with(|socket, _| {
+            socket
+                .listen(local_endpoint)
+                .map_err(SocketError::SmoltcpTcpListenError)
+        });
+        if let Err(error) = listen_result {
+            interface.remove_socket(new_listener_handle);
+            self.smoltcp_socket_handle = Some(old_handle);
+            return Err(error);
+        }
+
+        let mut accepted_socket = TcpSocket::new(
+            self.network_manager.clone(),
+            accepted_fd,
+            self.socket_domain,
+        );
+        accepted_socket.smoltcp_interface = Some(interface);
+        accepted_socket.smoltcp_socket_handle = Some(old_handle);
+
+        Ok(AcceptedSocket {
+            socket: Rc::new(RefCell::new(accepted_socket)),
+            local_endpoint: local_endpoint_connected,
+            remote_endpoint,
+        })
     }
 
     // TCP bind() : TCP Server side method, create smoltcp socket for tcp server
@@ -177,11 +289,7 @@ impl PosixSocket for TcpSocket {
             }
 
             match socket.state() {
-                State::SynSent
-                | State::SynReceived
-                | State::Listen
-                | State::CloseWait
-                | State::Established => {
+                State::SynSent | State::SynReceived | State::CloseWait | State::Established => {
                     if !is_nonblocking {
                         let wait_operation = Operation::Send {
                             socket_fd,
@@ -267,8 +375,7 @@ impl PosixSocket for TcpSocket {
                     log::debug!("{}", msg);
                     Ok(0)
                 }
-                State::SynSent | State::SynReceived | State::Established | State::Listen => {
-                    // FIXME: Treating Listen state as Established temporarily, since accept() is not implemented yet
+                State::SynSent | State::SynReceived | State::Established => {
                     if is_nonblocking {
                         // O_NONBLOCK is set, so return immediately without blocking
                         Err(SocketError::TryAgain)

--- a/kernel/src/net/smoltcp/socket/udp.rs
+++ b/kernel/src/net/smoltcp/socket/udp.rs
@@ -107,7 +107,14 @@ impl PosixSocket for UdpSocket {
         self.smoltcp_interface.replace(interface.clone());
     }
 
-    fn accept(&self, _local_endpoint: IpListenEndpoint) -> SocketResult {
+    fn accept(
+        &mut self,
+        _accepted_fd: crate::net::SocketFd,
+        _local_endpoint: IpListenEndpoint,
+        _accepted_connection: Arc<crate::net::connection::Connection>,
+        _is_nonblocking: bool,
+        _ipc_reply: Arc<OperationIPCReply>,
+    ) -> crate::net::socket::AcceptResult {
         Err(SocketError::UnsupportedSocketTypeForOperation(
             SocketType::SockDgram,
             "accept()".into(),

--- a/kernel/src/net/socket/mod.rs
+++ b/kernel/src/net/socket/mod.rs
@@ -14,8 +14,14 @@
 
 use smoltcp::wire::{IpAddress, IpEndpoint, IpListenEndpoint};
 
-use crate::net::{connection::OperationIPCReply, smoltcp::iface::NetIface, types::SocketResult};
+use crate::net::{
+    connection::{Connection, OperationIPCReply},
+    smoltcp::iface::NetIface,
+    types::SocketResult,
+    SocketFd,
+};
 use alloc::{boxed::Box, rc::Rc, sync::Arc};
+use core::cell::RefCell;
 
 pub mod socket_err;
 pub mod socket_waker;
@@ -25,11 +31,26 @@ pub(crate) type FnSendMsg = Box<dyn FnOnce(&mut [u8]) -> usize + Send>;
 pub(crate) type FnRecv = Box<dyn FnOnce(&mut [u8]) -> (usize, usize) + Send>;
 pub(crate) type FnRecvWithEndpoint = Box<dyn FnOnce(&[u8], IpEndpoint) -> usize + Send>;
 
+pub type AcceptResult = Result<AcceptedSocket, socket_err::SocketError>;
+
+pub struct AcceptedSocket {
+    pub socket: Rc<RefCell<dyn PosixSocket>>,
+    pub local_endpoint: IpEndpoint,
+    pub remote_endpoint: IpEndpoint,
+}
+
 pub trait PosixSocket {
     // smoltcp need to bind socket with interface
     fn bind_interface(&mut self, interface: Arc<NetIface>);
 
-    fn accept(&self, _local_endpoint: IpListenEndpoint) -> SocketResult;
+    fn accept(
+        &mut self,
+        accepted_fd: SocketFd,
+        local_endpoint: IpListenEndpoint,
+        accepted_connection: Arc<Connection>,
+        is_nonblocking: bool,
+        ipc_reply: Arc<OperationIPCReply>,
+    ) -> AcceptResult;
 
     fn bind(&mut self, local_endpoint: IpListenEndpoint) -> SocketResult;
 

--- a/kernel/src/net/socket/socket_err.rs
+++ b/kernel/src/net/socket/socket_err.rs
@@ -91,3 +91,18 @@ pub enum SocketError {
     #[error("smoltcp icmp recv error: {0}")]
     SmoltcpIcmpRecvError(smoltcp::socket::icmp::RecvError),
 }
+
+impl SocketError {
+    pub fn to_errno(&self) -> i32 {
+        match self {
+            Self::TryAgain | Self::WouldBlock => -libc::EAGAIN,
+            Self::InvalidSocketFd(_) => -libc::EBADF,
+            Self::UnsupportedSocketTypeForOperation(_, _) => -libc::EOPNOTSUPP,
+            Self::InvalidState(_) => -libc::EINVAL,
+            Self::PosixError(errno, _) => *errno,
+            Self::UnsupportedOperation => -libc::ENOSYS,
+            Self::InvalidParam(_, _) => -libc::EINVAL,
+            _ => -libc::EIO,
+        }
+    }
+}

--- a/kernel/src/net/syscalls.rs
+++ b/kernel/src/net/syscalls.rs
@@ -452,20 +452,10 @@ pub fn setsockopt(
     };
 
     // `option_name` identifies exactly one POSIX socket option; it is not a
-    // bitmask and multiple options cannot be ORed together. Use exact equality
-    // here because different option numbers may share bits. For example,
-    // SO_REUSEADDR (0x0004) & SO_RCVTIMEO (0x1006) is non-zero.
+    // bitmask and multiple options cannot be ORed together.
     if level == libc::SOL_SOCKET {
         if option_name == libc::SO_REUSEADDR {
-            if option_value.is_null()
-                || option_len < core::mem::size_of::<c_int>() as libc::socklen_t
-            {
-                return -1;
-            }
-
-            let reuse_address = unsafe { core::ptr::read_unaligned(option_value.cast::<c_int>()) };
-            connection.set_reuse_address(reuse_address != 0);
-            return 0;
+            return -libc::ENOPROTOOPT;
         }
 
         if option_name == libc::SO_RCVTIMEO {
@@ -519,19 +509,7 @@ pub fn getsockopt(
     // a set of flags, so each supported option must be matched exactly.
     if level == libc::SOL_SOCKET {
         if option_name == libc::SO_REUSEADDR {
-            let option_len_value = unsafe { *option_len };
-            if option_len_value < core::mem::size_of::<c_int>() as libc::socklen_t {
-                return -libc::EINVAL;
-            }
-
-            unsafe {
-                core::ptr::write_unaligned(
-                    option_value.cast::<c_int>(),
-                    c_int::from(connection.reuse_address()),
-                );
-                *option_len = core::mem::size_of::<c_int>() as libc::socklen_t;
-            }
-            return 0;
+            return -libc::ENOPROTOOPT;
         }
 
         if option_name == libc::SO_RCVTIMEO {
@@ -662,8 +640,11 @@ pub fn shutdown(socket: c_int, how: c_int) -> c_int {
         log::error!("fd={}: not a valid file descriptor", socket);
         return -libc::EBADF;
     };
-    free_sock_fd(socket);
-    connection.shutdown().map(|_| 0).unwrap_or(-1)
+    let result = connection.shutdown();
+    if result.is_ok() {
+        let _ = free_sock_fd(socket);
+    }
+    result.map(|_| 0).unwrap_or(-1)
 }
 
 pub fn getaddrinfo(

--- a/kernel/src/net/syscalls.rs
+++ b/kernel/src/net/syscalls.rs
@@ -364,7 +364,7 @@ pub fn recvfrom(
         log::debug!("Received packet from {:?}", endpoint);
 
         if let Some((mut address_ref, mut address_len_ref)) = recv_addr {
-            net::write_to_sockaddr(
+            let _ = net::write_to_sockaddr(
                 endpoint,
                 address_ref as *mut libc::sockaddr,
                 address_len_ref as *mut libc::socklen_t,
@@ -563,18 +563,62 @@ pub fn getsockopt(
 
 pub fn accept(
     socket: c_int,
-    _address: *mut libc::sockaddr,
-    _address_len: *mut libc::socklen_t,
+    address: *mut libc::sockaddr,
+    address_len: *mut libc::socklen_t,
 ) -> c_int {
     log::debug!("fd={}: Accepting connection", socket);
 
-    if let Err(e) = get_sock_by_fd(socket) {
+    let Ok(connection) = get_sock_by_fd(socket) else {
         log::warn!("fd={}: not a valid file descriptor", socket);
-        -libc::EBADF
-    } else {
-        // return socket fd when exit, do not support backlog
-        socket
+        return -libc::EBADF;
+    };
+
+    if connection.socket_type() != SocketType::SockStream {
+        log::warn!("fd={}: socket protocol does not support accept()", socket);
+        return -libc::EOPNOTSUPP;
     }
+
+    if !connection.is_listening() {
+        log::warn!("fd={}: socket is not listening", socket);
+        return -libc::EINVAL;
+    }
+
+    if address.is_null() != address_len.is_null() {
+        return -libc::EINVAL;
+    }
+
+    let accepted_fd = alloc_sock_fd(0);
+    if accepted_fd < 0 {
+        return -libc::EMFILE;
+    }
+
+    let accepted_connection = Arc::new(Connection::new_accepted(accepted_fd, &connection));
+    if sock_attach_to_fd(accepted_fd, accepted_connection.clone()).is_err() {
+        let _ = free_sock_fd(accepted_fd);
+        return -libc::EMFILE;
+    }
+
+    let result = connection.accept(accepted_fd, accepted_connection.clone());
+    if let Err(error) = result {
+        let _ = free_sock_fd(accepted_fd);
+        return error.to_errno();
+    }
+
+    if !address.is_null() {
+        let Some(remote_endpoint) = accepted_connection.remote_endpoint() else {
+            let _ = accepted_connection.shutdown();
+            let _ = free_sock_fd(accepted_fd);
+            return -libc::EIO;
+        };
+
+        if let Err(errno) = net::write_to_sockaddr(remote_endpoint, address, address_len) {
+            let _ = accepted_connection.shutdown();
+            let _ = free_sock_fd(accepted_fd);
+            return errno;
+        }
+    }
+
+    accepted_fd
 }
 
 pub fn shutdown(socket: c_int, how: c_int) -> c_int {

--- a/kernel/src/net/syscalls.rs
+++ b/kernel/src/net/syscalls.rs
@@ -451,9 +451,24 @@ pub fn setsockopt(
         return -libc::EBADF;
     };
 
-    // option_name suppose to contain only one option
+    // `option_name` identifies exactly one POSIX socket option; it is not a
+    // bitmask and multiple options cannot be ORed together. Use exact equality
+    // here because different option numbers may share bits. For example,
+    // SO_REUSEADDR (0x0004) & SO_RCVTIMEO (0x1006) is non-zero.
     if level == libc::SOL_SOCKET {
-        if (option_name & libc::SO_RCVTIMEO) != 0 {
+        if option_name == libc::SO_REUSEADDR {
+            if option_value.is_null()
+                || option_len < core::mem::size_of::<c_int>() as libc::socklen_t
+            {
+                return -1;
+            }
+
+            let reuse_address = unsafe { core::ptr::read_unaligned(option_value.cast::<c_int>()) };
+            connection.set_reuse_address(reuse_address != 0);
+            return 0;
+        }
+
+        if option_name == libc::SO_RCVTIMEO {
             return match unsafe { Timeval::from_ptr(option_value, option_len) } {
                 Some(timeval) => {
                     connection.set_recv_timeout(Duration::from(timeval));
@@ -463,7 +478,7 @@ pub fn setsockopt(
             };
         }
 
-        if (option_name & libc::SO_SNDTIMEO) != 0 {
+        if option_name == libc::SO_SNDTIMEO {
             return match unsafe { Timeval::from_ptr(option_value, option_len) } {
                 Some(timeval) => {
                     connection.set_send_timeout(Duration::from(timeval));
@@ -499,8 +514,27 @@ pub fn getsockopt(
     if option_value.is_null() || option_len.is_null() {
         return -libc::EINVAL;
     }
+
+    // As in setsockopt(), `option_name` is a single option number rather than
+    // a set of flags, so each supported option must be matched exactly.
     if level == libc::SOL_SOCKET {
-        if (option_name & libc::SO_RCVTIMEO) != 0 {
+        if option_name == libc::SO_REUSEADDR {
+            let option_len_value = unsafe { *option_len };
+            if option_len_value < core::mem::size_of::<c_int>() as libc::socklen_t {
+                return -libc::EINVAL;
+            }
+
+            unsafe {
+                core::ptr::write_unaligned(
+                    option_value.cast::<c_int>(),
+                    c_int::from(connection.reuse_address()),
+                );
+                *option_len = core::mem::size_of::<c_int>() as libc::socklen_t;
+            }
+            return 0;
+        }
+
+        if option_name == libc::SO_RCVTIMEO {
             let timeval = Timeval::from(connection.get_recv_timeout());
             unsafe {
                 core::ptr::copy_nonoverlapping(&timeval, option_value as *mut Timeval, ONE_ELEMENT);
@@ -509,7 +543,7 @@ pub fn getsockopt(
             return 0;
         }
 
-        if (option_name & libc::SO_SNDTIMEO) != 0 {
+        if option_name == libc::SO_SNDTIMEO {
             let timeval = Timeval::from(connection.get_send_timeout());
             unsafe {
                 core::ptr::copy_nonoverlapping(&timeval, option_value as *mut Timeval, ONE_ELEMENT);

--- a/kernel/src/net/syscalls.rs
+++ b/kernel/src/net/syscalls.rs
@@ -563,8 +563,8 @@ pub fn getsockopt(
 
 pub fn accept(
     socket: c_int,
-    _address: *const libc::sockaddr,
-    _address_len: libc::socklen_t,
+    _address: *mut libc::sockaddr,
+    _address_len: *mut libc::socklen_t,
 ) -> c_int {
     log::debug!("fd={}: Accepting connection", socket);
 

--- a/kernel/src/net/types.rs
+++ b/kernel/src/net/types.rs
@@ -567,43 +567,44 @@ pub fn write_to_sockaddr(
     endpoint: IpEndpoint,
     sockaddr_ptr: *mut libc::sockaddr,
     socklen_ptr: *mut libc::socklen_t,
-) {
-    if socklen_ptr as usize >= core::mem::size_of::<libc::sockaddr>() {
-        match endpoint.addr {
-            IpAddress::Ipv4(ipv4) => unsafe {
-                let addr_len = core::mem::size_of::<libc::sockaddr_in>();
-                let sockaddr_ptr = sockaddr_ptr.cast::<libc::sockaddr_in>();
-                // addr
-                (*sockaddr_ptr).sin_len = addr_len as u8;
-                (*sockaddr_ptr).sin_family = libc::AF_INET as libc::sa_family_t;
-                (*sockaddr_ptr).sin_port = u16::from_be(endpoint.port);
-                (*sockaddr_ptr).sin_addr.s_addr = u32::from_ne_bytes(ipv4.octets());
-                let addr_ptr = sockaddr_ptr
-                    .cast::<u8>()
-                    .add(core::mem::offset_of!(libc::sockaddr_in, sin_zero));
-                core::ptr::write_bytes(addr_ptr, 0, 6);
-
-                // addr len
-                *socklen_ptr = addr_len as libc::socklen_t;
-            },
-            IpAddress::Ipv6(ipv6) => unsafe {
-                let addr_len = core::mem::size_of::<libc::sockaddr_in6>();
-                let sockaddr_ptr = sockaddr_ptr.cast::<libc::sockaddr_in6>();
-
-                // addr
-                (*sockaddr_ptr).sin6_len = addr_len as u8;
-                (*sockaddr_ptr).sin6_family = libc::AF_INET6 as libc::sa_family_t;
-                (*sockaddr_ptr).sin6_port = u16::from_be(endpoint.port);
-                (*sockaddr_ptr).sin6_flowinfo = 0;
-                (*sockaddr_ptr).sin6_addr.s6_addr = ipv6.octets();
-                (*sockaddr_ptr).sin6_vport = 0;
-                (*sockaddr_ptr).sin6_scope_id = 0;
-
-                // addr len
-                *socklen_ptr = addr_len as libc::socklen_t;
-            },
-        }
+) -> Result<(), i32> {
+    if sockaddr_ptr.is_null() || socklen_ptr.is_null() {
+        return Err(-libc::EINVAL);
     }
+
+    let user_len = unsafe { *socklen_ptr as usize };
+    match endpoint.addr {
+        IpAddress::Ipv4(ipv4) => unsafe {
+            let addr_len = core::mem::size_of::<libc::sockaddr_in>();
+            let mut address: libc::sockaddr_in = core::mem::zeroed();
+            address.sin_len = addr_len as u8;
+            address.sin_family = libc::AF_INET as libc::sa_family_t;
+            address.sin_port = u16::from_be(endpoint.port);
+            address.sin_addr.s_addr = u32::from_ne_bytes(ipv4.octets());
+            core::ptr::copy_nonoverlapping(
+                (&address as *const libc::sockaddr_in).cast::<u8>(),
+                sockaddr_ptr.cast::<u8>(),
+                user_len.min(addr_len),
+            );
+            *socklen_ptr = addr_len as libc::socklen_t;
+        },
+        IpAddress::Ipv6(ipv6) => unsafe {
+            let addr_len = core::mem::size_of::<libc::sockaddr_in6>();
+            let mut address: libc::sockaddr_in6 = core::mem::zeroed();
+            address.sin6_len = addr_len as u8;
+            address.sin6_family = libc::AF_INET6 as libc::sa_family_t;
+            address.sin6_port = u16::from_be(endpoint.port);
+            address.sin6_addr.s6_addr = ipv6.octets();
+            core::ptr::copy_nonoverlapping(
+                (&address as *const libc::sockaddr_in6).cast::<u8>(),
+                sockaddr_ptr.cast::<u8>(),
+                user_len.min(addr_len),
+            );
+            *socklen_ptr = addr_len as libc::socklen_t;
+        },
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
@@ -684,5 +685,49 @@ mod tests {
         );
 
         assert_eq!(result, Err(-1));
+    }
+
+    #[test]
+    fn write_to_sockaddr_ipv4() {
+        let endpoint = IpEndpoint::new(
+            IpAddress::Ipv4(core::net::Ipv4Addr::new(127, 0, 0, 1)),
+            8080,
+        );
+        let mut address: libc::sockaddr_in = unsafe { core::mem::zeroed() };
+        let mut len = size_of::<libc::sockaddr_in>() as libc::socklen_t;
+
+        write_to_sockaddr(
+            endpoint,
+            (&mut address as *mut libc::sockaddr_in).cast(),
+            &mut len,
+        )
+        .unwrap();
+
+        assert_eq!(address.sin_family as i32, libc::AF_INET);
+        assert_eq!(u16::from_be(address.sin_port), 8080);
+        assert_eq!(address.sin_addr.s_addr.to_ne_bytes(), [127, 0, 0, 1]);
+        assert_eq!(len as usize, size_of::<libc::sockaddr_in>());
+    }
+
+    #[test]
+    fn write_to_sockaddr_ipv6() {
+        let endpoint = IpEndpoint::new(IpAddress::Ipv6(core::net::Ipv6Addr::LOCALHOST), 8080);
+        let mut address: libc::sockaddr_in6 = unsafe { core::mem::zeroed() };
+        let mut len = size_of::<libc::sockaddr_in6>() as libc::socklen_t;
+
+        write_to_sockaddr(
+            endpoint,
+            (&mut address as *mut libc::sockaddr_in6).cast(),
+            &mut len,
+        )
+        .unwrap();
+
+        assert_eq!(address.sin6_family as i32, libc::AF_INET6);
+        assert_eq!(u16::from_be(address.sin6_port), 8080);
+        assert_eq!(
+            address.sin6_addr.s6_addr,
+            core::net::Ipv6Addr::LOCALHOST.octets()
+        );
+        assert_eq!(len as usize, size_of::<libc::sockaddr_in6>());
     }
 }

--- a/kernel/src/syscall_handlers/mod.rs
+++ b/kernel/src/syscall_handlers/mod.rs
@@ -136,7 +136,7 @@ mod net_syscalls {
     pub fn listen(_socket: c_int, _backlog: c_int) -> c_int {
         -libc::ENOTSUP
     }
-    pub fn accept(_socket: c_int, _address: *const sockaddr, _address_len: u32) -> c_int {
+    pub fn accept(_socket: c_int, _address: *mut sockaddr, _address_len: *mut socklen_t) -> c_int {
         -libc::ENOTSUP
     }
     pub fn send(
@@ -689,18 +689,7 @@ define_syscall_handler!(
 
 define_syscall_handler!(
     accept(sockfd: c_int, addr: *mut sockaddr, len: *mut socklen_t) -> c_int {
-        let orig_len = if !len.is_null() { unsafe { *len } } else { 0 };
-
-        let result = net_syscalls::accept(
-            sockfd,
-            addr as *const sockaddr,
-            orig_len
-        );
-        if !len.is_null() && result >= 0 {
-            unsafe { *len = orig_len };
-        }
-
-        result
+        net_syscalls::accept(sockfd, addr, len)
     }
 );
 

--- a/kernel/tests/net/test_socket_tcp.rs
+++ b/kernel/tests/net/test_socket_tcp.rs
@@ -89,13 +89,63 @@ fn tcp_server_thread(args: Arc<NetTestArgs>) {
         })),
     );
 
+    let mut peer_address: libc::sockaddr_storage = unsafe { mem::zeroed() };
+    let mut peer_address_len = mem::size_of::<libc::sockaddr_storage>() as libc::socklen_t;
+    let mut accepted_fd = -1;
+    net_utils::loop_with_io_mode(!args.is_nonblocking, || {
+        accepted_fd = net::syscalls::accept(
+            sock_fd,
+            (&mut peer_address as *mut libc::sockaddr_storage).cast(),
+            &mut peer_address_len,
+        );
+        if accepted_fd >= 0 {
+            true
+        } else {
+            scheduler::yield_me();
+            false
+        }
+    });
+    assert!(accepted_fd >= 0, "Failed to accept TCP connection.");
+    assert_ne!(accepted_fd, sock_fd, "accept() must return a new fd");
+    match args.domain {
+        SocketDomain::AfInet => {
+            assert_eq!(
+                peer_address_len as usize,
+                mem::size_of::<libc::sockaddr_in>()
+            );
+            let peer = unsafe {
+                &*((&peer_address as *const libc::sockaddr_storage).cast::<libc::sockaddr_in>())
+            };
+            assert_eq!(peer.sin_family as i32, AF_INET);
+            assert_eq!(peer.sin_addr.s_addr.to_ne_bytes(), [127, 0, 0, 1]);
+        }
+        SocketDomain::AfInet6 => {
+            assert_eq!(
+                peer_address_len as usize,
+                mem::size_of::<libc::sockaddr_in6>()
+            );
+            let peer = unsafe {
+                &*((&peer_address as *const libc::sockaddr_storage).cast::<libc::sockaddr_in6>())
+            };
+            assert_eq!(peer.sin6_family as i32, AF_INET6);
+            assert_eq!(
+                peer.sin6_addr.s6_addr,
+                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]
+            );
+        }
+    }
+
     let mut buffer = vec![0u8; 1024];
     let mut received_text = false;
     let mut received_eof = false;
     net_utils::loop_with_io_mode(!args.is_nonblocking, || {
-        let mut bytes_received =
-            net::syscalls::recv(sock_fd, buffer.as_mut_ptr() as *mut c_void, buffer.len(), 0);
-        println!("Socket[{}] recv {} bytes", sock_fd, bytes_received);
+        let mut bytes_received = net::syscalls::recv(
+            accepted_fd,
+            buffer.as_mut_ptr() as *mut c_void,
+            buffer.len(),
+            0,
+        );
+        println!("Socket[{}] recv {} bytes", accepted_fd, bytes_received);
 
         match bytes_received.cmp(&0) {
             cmp::Ordering::Greater => {
@@ -103,7 +153,7 @@ fn tcp_server_thread(args: Arc<NetTestArgs>) {
 
                 // Attempt to convert received bytes to UTF-8 string (lossy to avoid errors)
                 let text = String::from_utf8_lossy(&buffer[..received_size]);
-                println!("Socket[{}] recv TCP text: {}", sock_fd, text);
+                println!("Socket[{}] recv TCP text: {}", accepted_fd, text);
 
                 // Print received data in hex format
                 net_utils::println_hex(&buffer[..received_size], received_size);
@@ -113,7 +163,7 @@ fn tcp_server_thread(args: Arc<NetTestArgs>) {
             cmp::Ordering::Less => {
                 println!(
                     "Socket[{}] unexpected bytes_received={}",
-                    sock_fd, bytes_received
+                    accepted_fd, bytes_received
                 );
                 if received_text {
                     // Exit the test loop once text is received to avoid EOF wait timeout
@@ -122,7 +172,7 @@ fn tcp_server_thread(args: Arc<NetTestArgs>) {
             }
             cmp::Ordering::Equal => {
                 // bytes_received == 0 means EOF
-                println!("Socket[{}] recv TCP EOF", sock_fd);
+                println!("Socket[{}] recv TCP EOF", accepted_fd);
                 received_eof = true;
                 return true; // Indicate EOF received
             }
@@ -137,11 +187,20 @@ fn tcp_server_thread(args: Arc<NetTestArgs>) {
         "Failed to receive data or EOF."
     );
 
-    let shutdown_result = net::syscalls::shutdown(sock_fd, 0);
-    println!("Socket[{}] shutdown result {}", sock_fd, shutdown_result);
+    let shutdown_result = net::syscalls::shutdown(accepted_fd, 0);
+    println!(
+        "Socket[{}] shutdown result {}",
+        accepted_fd, shutdown_result
+    );
     assert!(
         shutdown_result == 0,
-        "Failed to shutdown tcp server socket."
+        "Failed to shutdown accepted tcp socket."
+    );
+
+    assert_eq!(
+        net::syscalls::shutdown(sock_fd, 0),
+        0,
+        "Failed to shutdown listening tcp socket."
     );
 
     TCP_SERVER_THREAD_FINISH.store(1, Ordering::Release);

--- a/kernel/tests/test_vfs.rs
+++ b/kernel/tests/test_vfs.rs
@@ -741,7 +741,14 @@ fn create_connected_sockets() -> (i32, i32) {
     assert_eq!(_connect_result, 0, "Failed to connect client");
     println!("Client connected successfully");
 
-    (server_fd, client_fd)
+    let accepted_fd =
+        net::syscalls::accept(server_fd, core::ptr::null_mut(), core::ptr::null_mut());
+    assert!(accepted_fd >= 0, "Failed to accept client connection");
+    assert_ne!(accepted_fd, server_fd, "accept() must return a new fd");
+
+    close(server_fd);
+
+    (accepted_fd, client_fd)
 }
 
 const TEST_NONBLOCK_MODE: usize = 20;


### PR DESCRIPTION
## Summary
- Implement TCP `accept()` end to end across the syscall, IPC, network manager, and smoltcp TCP layers.
- Return a distinct accepted fd and preserve the listener for subsequent sequential accepts.
- Support blocking and nonblocking accept behavior, peer address output, and transactional fd cleanup on failure.
- Add shared local-port leases so listener and accepted sockets release the port exactly once.
- Support `SO_REUSEADDR`, which `std::net::TcpListener::bind()` sets before binding a listener.
- Add IPv4/IPv6 TCP accept coverage and update socket/VFS tests to use the accepted fd.

## Design
- A connected smoltcp TCP handle is transferred to the accepted socket.
- The listener receives a fresh smoltcp handle and resumes listening.
- The implementation intentionally provides sequential accept with an effective backlog of one; a queued multi-connection backlog requires a pending connection queue and multiple listener handles.
- Closed protocol sockets are removed from `NetworkManager` after successful shutdown, and RefCell borrow scopes are explicit around that cleanup.
- Socket option names are matched by exact value rather than as bit flags. POSIX `option_name` selects one option, and constants can share bits; for example, `SO_REUSEADDR (0x0004) & SO_RCVTIMEO (0x1006)` is non-zero.
- The `SO_REUSEADDR` state is stored on `Connection`, exposed through `setsockopt()`/`getsockopt()`, and inherited by accepted connections. The current port allocator remains strict because BlueOS does not retain port leases for TCP `TIME_WAIT` sockets.

## Testing
- `rustfmt --check` on all changed Rust files
- `git diff --check`
- `ninja -C out/qemu_mps2_an385.debug obj/kernel/kernel/blueos/libblueos.rlib`
- `ninja -C out/seeed_xiao_esp32c3.debug tcp_server_example`

`kernel_unittest` reaches final linking but is currently blocked by the repository/toolchain `log -> std` versus kernel `panic_impl` duplicate lang-item error.

## Related
- Supersedes the type-only accept change in #452.
- Includes the socket-map cleanup from #451.
