### PR TITLE
net: preserve socket errors across syscall boundaries

### DIFF
--- a/kernel/src/net/connection_err.rs
+++ b/kernel/src/net/connection_err.rs
@@ -53,6 +53,22 @@ pub enum ConnectionError {
     SocketOperationError(SocketError),
 }
 
+impl ConnectionError {
+    pub fn to_errno(&self) -> i32 {
+        match self {
+            Self::SocketOperationError(error) => error.to_errno(),
+            Self::NetStackQueueFull => -libc::EAGAIN,
+            Self::PosixError(error) => error.to_errno(),
+            Self::UnsupportedSocketType(_) => -libc::EOPNOTSUPP,
+            Self::NoAvailableDynamicPort => -libc::EADDRNOTAVAIL,
+            Self::PortInUse(_) => -libc::EADDRINUSE,
+            Self::PortOutOfRange(_, _) => -libc::EINVAL,
+            Self::Timeout(_) => -libc::ETIMEDOUT,
+            Self::LockFail(_) => -libc::EIO,
+        }
+    }
+}
+
 impl From<SocketError> for ConnectionError {
     fn from(err: SocketError) -> Self {
         Self::SocketOperationError(err)
@@ -62,5 +78,27 @@ impl From<SocketError> for ConnectionError {
 impl From<Error> for ConnectionError {
     fn from(err: Error) -> Self {
         Self::PosixError(err)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use blueos_test_macro::test;
+
+    #[test]
+    fn maps_connection_errors_to_negative_errno() {
+        assert_eq!(ConnectionError::Timeout(1000).to_errno(), -libc::ETIMEDOUT);
+        assert_eq!(ConnectionError::NetStackQueueFull.to_errno(), -libc::EAGAIN);
+        assert_eq!(ConnectionError::PortInUse(80).to_errno(), -libc::EADDRINUSE);
+    }
+
+    #[test]
+    fn preserves_nested_error_errno() {
+        let socket_error = ConnectionError::from(SocketError::InvalidSocketFd(7));
+        assert_eq!(socket_error.to_errno(), -libc::EBADF);
+
+        let posix_error = ConnectionError::from(Error::from_errno(-libc::EINTR));
+        assert_eq!(posix_error.to_errno(), -libc::EINTR);
     }
 }

--- a/kernel/src/net/socket/socket_err.rs
+++ b/kernel/src/net/socket/socket_err.rs
@@ -91,3 +91,37 @@ pub enum SocketError {
     #[error("smoltcp icmp recv error: {0}")]
     SmoltcpIcmpRecvError(smoltcp::socket::icmp::RecvError),
 }
+
+impl SocketError {
+    pub fn to_errno(&self) -> i32 {
+        match self {
+            Self::TryAgain | Self::WouldBlock => -libc::EAGAIN,
+            Self::InvalidSocketFd(_) => -libc::EBADF,
+            Self::UnsupportedSocketTypeForOperation(_, _) => -libc::EOPNOTSUPP,
+            Self::InvalidState(_) => -libc::EINVAL,
+            Self::PosixError(errno, _) => *errno,
+            Self::UnsupportedOperation => -libc::ENOSYS,
+            Self::InvalidParam(_, _) => -libc::EINVAL,
+            _ => -libc::EIO,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use blueos_test_macro::test;
+
+    #[test]
+    fn maps_socket_errors_to_negative_errno() {
+        assert_eq!(SocketError::WouldBlock.to_errno(), -libc::EAGAIN);
+        assert_eq!(SocketError::InvalidSocketFd(3).to_errno(), -libc::EBADF);
+        assert_eq!(SocketError::UnsupportedOperation.to_errno(), -libc::ENOSYS);
+    }
+
+    #[test]
+    fn preserves_explicit_posix_errno() {
+        let error = SocketError::PosixError(-libc::ECONNRESET, String::new());
+        assert_eq!(error.to_errno(), -libc::ECONNRESET);
+    }
+}

--- a/kernel/src/net/syscalls.rs
+++ b/kernel/src/net/syscalls.rs
@@ -97,7 +97,10 @@ pub fn listen(socket: c_int, backlog: c_int) -> c_int {
         log::warn!("fd={}: socket is unbound", socket);
         return -libc::EDESTADDRREQ;
     }
-    connection.listen().map(|_| 0).unwrap_or(-1)
+    connection
+        .listen()
+        .map(|_| 0)
+        .unwrap_or_else(|error| error.to_errno())
 }
 
 pub fn send(socket: c_int, buffer: *const c_void, length: c_size_t, flags: c_int) -> c_ssize_t {
@@ -138,7 +141,7 @@ pub fn send(socket: c_int, buffer: *const c_void, length: c_size_t, flags: c_int
     connection
         .send(f, flags)
         .map(|send_sizes| send_sizes.try_into().unwrap_or(-1))
-        .unwrap_or(-1)
+        .unwrap_or_else(|error| error.to_errno() as c_ssize_t)
 }
 
 pub fn sendto(
@@ -182,7 +185,7 @@ pub fn sendto(
     connection
         .sendto(buf, flags, remote_endpoint)
         .map(|send_sizes| send_sizes.try_into().unwrap_or(-1))
-        .unwrap_or(-1)
+        .unwrap_or_else(|error| error.to_errno() as c_ssize_t)
 }
 
 pub fn sendmsg(socket: c_int, message: *const libc::msghdr, flags: c_int) -> c_ssize_t {
@@ -233,7 +236,7 @@ pub fn sendmsg(socket: c_int, message: *const libc::msghdr, flags: c_int) -> c_s
     connection
         .sendmsg(remote_endpoint, identifier, packet_len, send_payload)
         .map(|send_sizes| send_sizes.try_into().unwrap_or(-1))
-        .unwrap_or(-1)
+        .unwrap_or_else(|error| error.to_errno() as c_ssize_t)
 }
 
 pub fn recv(socket: c_int, buffer: *mut c_void, length: c_size_t, flags: c_int) -> c_ssize_t {
@@ -279,7 +282,7 @@ pub fn recv(socket: c_int, buffer: *mut c_void, length: c_size_t, flags: c_int) 
             log::debug!("[Posix] recv msg recv_sized={}", recv_sized);
             recv_sized.try_into().unwrap_or(-1)
         })
-        .unwrap_or(-1)
+        .unwrap_or_else(|error| error.to_errno() as c_ssize_t)
 }
 
 pub fn recvmsg(socket: c_int, message: *mut libc::msghdr, flags: c_int) -> c_ssize_t {
@@ -322,7 +325,7 @@ pub fn recvmsg(socket: c_int, message: *mut libc::msghdr, flags: c_int) -> c_ssi
     connection
         .recvmsg(recv_payload)
         .map(|recv_sized| recv_sized.try_into().unwrap_or(-1))
-        .unwrap_or(-1)
+        .unwrap_or_else(|error| error.to_errno() as c_ssize_t)
 }
 
 pub fn recvfrom(
@@ -379,7 +382,7 @@ pub fn recvfrom(
     connection
         .recvfrom(recv_payload)
         .map(|recv_sized| recv_sized.try_into().unwrap_or(-1))
-        .unwrap_or(-1)
+        .unwrap_or_else(|error| error.to_errno() as c_ssize_t)
 }
 
 pub fn connect(
@@ -404,7 +407,10 @@ pub fn connect(
         return -libc::EADDRNOTAVAIL;
     };
 
-    connection.connect(remote_endpoint).map(|_| 0).unwrap_or(-1)
+    connection
+        .connect(remote_endpoint)
+        .map(|_| 0)
+        .unwrap_or_else(|error| error.to_errno())
 }
 
 pub fn bind(socket: c_int, address: *const libc::sockaddr, address_len: libc::socklen_t) -> c_int {
@@ -433,8 +439,10 @@ pub fn bind(socket: c_int, address: *const libc::sockaddr, address_len: libc::so
     connection
         .bind(local_endpoint)
         .map(|_| 0)
-        .map_err(|e| log::debug!("bind fail {:#?}", e))
-        .unwrap_or(-1)
+        .unwrap_or_else(|error| {
+            log::debug!("bind fail {:#?}", error);
+            error.to_errno()
+        })
 }
 
 pub fn setsockopt(
@@ -585,7 +593,10 @@ pub fn shutdown(socket: c_int, how: c_int) -> c_int {
         return -libc::EBADF;
     };
     free_sock_fd(socket);
-    connection.shutdown().map(|_| 0).unwrap_or(-1)
+    connection
+        .shutdown()
+        .map(|_| 0)
+        .unwrap_or_else(|error| error.to_errno())
 }
 
 pub fn getaddrinfo(

--- a/kernel/src/vfs/sockfs.rs
+++ b/kernel/src/vfs/sockfs.rs
@@ -110,7 +110,7 @@ impl FileOps for SocketFile {
             Ok(recv_size) => Ok(recv_size),
             Err(e) => {
                 warn!("SocketFile read: connection.recv {}", e);
-                Err(code::ERROR)
+                Err(Error::from_errno(e.to_errno()))
             }
         }
     }
@@ -139,7 +139,7 @@ impl FileOps for SocketFile {
             Ok(sent) => Ok(sent),
             Err(e) => {
                 warn!("SocketFile write: connection.send {}", e);
-                Err(code::ERROR)
+                Err(Error::from_errno(e.to_errno()))
             }
         }
     }


### PR DESCRIPTION
## Summary
- Map `ConnectionError` and `SocketError` variants to specific negative POSIX errno values.
- Preserve those errors through socket syscalls instead of collapsing every failure to `-1`.
- Preserve socket read/write errors through sockfs instead of returning the generic `code::ERROR`.
- Add unit coverage for common mappings and nested error forwarding.

## Motivation
The BlueOS network stack already distinguishes conditions such as timeout, would-block, invalid file descriptor, queue exhaustion, and address conflicts. The socket syscall and VFS boundaries previously collapsed these failures to a generic `-1`, losing the original reason before it reached libc.

For example, a timeout should leave the kernel as `-ETIMEDOUT`, allowing the libc wrapper to return `-1` with `errno = ETIMEDOUT`. Returning a bare `-1` from the kernel instead makes the libc layer interpret the error number as `1` or observe stale errno.

This complements [vivoblueos/librs#38](https://github.com/vivoblueos/librs/pull/38), which converts negative kernel errno results to the POSIX libc `-1` plus `errno` convention.

This PR only preserves reported errors. It does not implement socket timeout enforcement or change network operation behavior.

## POSIX references
- [`errno`](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/errno.h.html)
- [`send()`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/send.html)
- [`recv()`](https://pubs.opengroup.org/onlinepubs/9699919799/functions/recv.html)

## Testing
- Added unit tests for connection and socket errno mappings.
- `rustfmt --check kernel/src/net/connection_err.rs kernel/src/net/socket/socket_err.rs kernel/src/net/syscalls.rs kernel/src/vfs/sockfs.rs`
- `git diff --check`
- No board build was run.